### PR TITLE
feat(grill): plural subscribed account hooks

### DIFF
--- a/.changeset/plural-subscribed-hooks.md
+++ b/.changeset/plural-subscribed-hooks.md
@@ -1,0 +1,8 @@
+---
+"@macalinao/grill": minor
+---
+
+Add real-time subscription support to the plural account hooks. `useAccounts` and `useTokenAccounts` (and any hook built with `createDecodedAccountsHook`) now accept `subscribeToUpdates`, mirroring the singular `useAccount`/`useTokenAccount`.
+
+- New `useAccountsSubscription(addresses, decoder, enabled)` hook — the plural counterpart to `useAccountSubscription`, stable against fresh array references.
+- Export `createAccountDecoderFromDecoder`, the `Decoder` → `AccountDecoder` adapter previously private to `useAccount`, so consumers of the raw `SubscriptionManager` no longer need to hand-write it.

--- a/.changeset/plural-subscribed-hooks.md
+++ b/.changeset/plural-subscribed-hooks.md
@@ -6,3 +6,4 @@ Add real-time subscription support to the plural account hooks. `useAccounts` an
 
 - New `useAccountsSubscription(addresses, decoder, enabled)` hook — the plural counterpart to `useAccountSubscription`, stable against fresh array references.
 - Export `createAccountDecoderFromDecoder`, the `Decoder` → `AccountDecoder` adapter previously private to `useAccount`, so consumers of the raw `SubscriptionManager` no longer need to hand-write it.
+- The plural hooks' `addresses` now accepts a nullable, readonly array, so the result of a plural PDA hook like `useAssociatedTokenPdas` can be passed directly (`addresses: atas`) without `?? []`.

--- a/packages/grill/src/contexts/subscription-context.ts
+++ b/packages/grill/src/contexts/subscription-context.ts
@@ -1,4 +1,10 @@
-import type { Account, Address, EncodedAccount, Lamports } from "@solana/kit";
+import type {
+  Account,
+  Address,
+  Decoder,
+  EncodedAccount,
+  Lamports,
+} from "@solana/kit";
 import type { QueryClient } from "@tanstack/react-query";
 import type { RpcSubscriptions, SolanaRpcSubscriptionsApi } from "gill";
 import { getBase64Encoder } from "@solana/kit";
@@ -16,6 +22,36 @@ export type AccountData = object | Uint8Array;
 export type AccountDecoder<T extends AccountData> = (
   encodedAccount: EncodedAccount,
 ) => Account<T>;
+
+/**
+ * Adapts a `Decoder<TDecodedData>` to an `AccountDecoder<TDecodedData>` for use
+ * with the {@link SubscriptionManager}.
+ *
+ * The subscription manager hands decoders an `EncodedAccount` (address, lamports,
+ * raw `data` bytes, ...), whereas a plain `Decoder` only knows how to decode the
+ * `data` byte array. This wraps the plain decoder so it produces a full
+ * `Account<TDecodedData>`, mirroring how account reads are decoded.
+ *
+ * @param decoder - The decoder for the account's `data` byte array, or undefined.
+ * @returns An `AccountDecoder`, or undefined if no decoder was provided.
+ */
+export function createAccountDecoderFromDecoder<
+  TDecodedData extends AccountData,
+>(
+  decoder: Decoder<TDecodedData> | undefined,
+): AccountDecoder<TDecodedData> | undefined {
+  if (!decoder) {
+    return undefined;
+  }
+
+  return (encodedAccount: EncodedAccount): Account<TDecodedData> => {
+    const decoded = decoder.decode(encodedAccount.data);
+    return {
+      ...encodedAccount,
+      data: decoded,
+    };
+  };
+}
 
 /**
  * Internal subscription entry tracking the WebSocket subscription and reference count.

--- a/packages/grill/src/hooks/create-decoded-accounts-hook.ts
+++ b/packages/grill/src/hooks/create-decoded-accounts-hook.ts
@@ -5,14 +5,14 @@ import { useAccounts } from "./use-accounts.js";
 
 export type DecodedAccountsResult<TData extends object> =
   UseAccountsResult<TData> & {
-    addresses: (Address | null | undefined)[];
+    addresses: readonly (Address | null | undefined)[];
   };
 
 /**
  * Input for a decoded accounts hook.
  */
 export type UseDecodedAccountsInput = {
-  addresses: (Address | null | undefined)[];
+  addresses: readonly (Address | null | undefined)[] | null | undefined;
 } & UseAccountOptions;
 
 /**

--- a/packages/grill/src/hooks/create-decoded-accounts-hook.ts
+++ b/packages/grill/src/hooks/create-decoded-accounts-hook.ts
@@ -1,4 +1,5 @@
 import type { Address, Decoder } from "@solana/kit";
+import type { UseAccountOptions } from "./use-account.js";
 import type { UseAccountsResult } from "./use-accounts.js";
 import { useAccounts } from "./use-accounts.js";
 
@@ -8,11 +9,18 @@ export type DecodedAccountsResult<TData extends object> =
   };
 
 /**
+ * Input for a decoded accounts hook.
+ */
+export type UseDecodedAccountsInput = {
+  addresses: (Address | null | undefined)[];
+} & UseAccountOptions;
+
+/**
  * A hook for fetching and decoding multiple accounts.
  */
-export type UseDecodedAccountsHook<TData extends object> = (args: {
-  addresses: (Address | null | undefined)[];
-}) => UseAccountsResult<TData>;
+export type UseDecodedAccountsHook<TData extends object> = (
+  args: UseDecodedAccountsInput,
+) => UseAccountsResult<TData>;
 
 /**
  * Generic helper to create a hook for fetching and decoding multiple accounts
@@ -24,12 +32,12 @@ export function createDecodedAccountsHook<TData extends object>(
 ): UseDecodedAccountsHook<TData> {
   return function useDecodedAccounts({
     addresses,
-  }: {
-    addresses: (Address | null | undefined)[];
-  }): UseAccountsResult<TData> {
+    subscribeToUpdates,
+  }: UseDecodedAccountsInput): UseAccountsResult<TData> {
     return useAccounts({
       addresses,
       decoder,
+      subscribeToUpdates,
     });
   };
 }

--- a/packages/grill/src/hooks/index.ts
+++ b/packages/grill/src/hooks/index.ts
@@ -5,6 +5,7 @@ export * from "./create-pdas-hook.js";
 export * from "./use-account.js";
 export * from "./use-account-subscription.js";
 export * from "./use-accounts.js";
+export * from "./use-accounts-subscription.js";
 export * from "./use-associated-token-account.js";
 export * from "./use-ata-balance.js";
 export { useConnectedWallet } from "./use-connected-wallet.js";

--- a/packages/grill/src/hooks/use-account.ts
+++ b/packages/grill/src/hooks/use-account.ts
@@ -3,16 +3,15 @@ import type {
   Account,
   Address,
   Decoder,
-  EncodedAccount,
   FetchAccountConfig,
   Simplify,
 } from "gill";
-import type { AccountDecoder } from "../contexts/subscription-context.js";
 import type { GillUseRpcHook } from "./types.js";
 import { fetchAndDecodeAccount } from "@macalinao/gill-extra";
 import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { useGrillContext } from "../contexts/grill-context.js";
+import { createAccountDecoderFromDecoder } from "../contexts/subscription-context.js";
 import { createAccountQueryKey } from "../query-keys.js";
 import { useAccountSubscription } from "./use-account-subscription.js";
 
@@ -76,26 +75,6 @@ export type UseAccountResult<TDecodedData extends object> =
   UseQueryResult<Account<TDecodedData> | null> & {
     address: Address | null | undefined;
   };
-
-/**
- * Adapts a Decoder to an AccountDecoder for subscriptions.
- * The decoder needs to be wrapped to handle the EncodedAccount format from subscriptions.
- */
-function createAccountDecoderFromDecoder<TDecodedData extends object>(
-  decoder: Decoder<TDecodedData> | undefined,
-): AccountDecoder<TDecodedData> | undefined {
-  if (!decoder) {
-    return undefined;
-  }
-
-  return (encodedAccount: EncodedAccount): Account<TDecodedData> => {
-    const decoded = decoder.decode(encodedAccount.data);
-    return {
-      ...encodedAccount,
-      data: decoded,
-    };
-  };
-}
 
 /**
  * Get the account info for an address. Concurrent queries are batched using a DataLoader.

--- a/packages/grill/src/hooks/use-accounts-subscription.ts
+++ b/packages/grill/src/hooks/use-accounts-subscription.ts
@@ -1,0 +1,70 @@
+import type { Address } from "@solana/kit";
+import type {
+  AccountData,
+  AccountDecoder,
+} from "../contexts/subscription-context.js";
+import { useEffect, useMemo } from "react";
+import { useSubscriptionManager } from "../contexts/subscription-context.js";
+
+/**
+ * Hook to subscribe to changes for multiple accounts via the SubscriptionManager.
+ *
+ * This is the plural counterpart to `useAccountSubscription`. It:
+ * - Subscribes each address through the SubscriptionManager (de-duplicated,
+ *   reference-counted WebSocket subscriptions shared with any other subscriber)
+ * - Writes decoded updates back to the shared account query keys, so plural
+ *   reads (`useAccounts` / `useTokenAccounts`) update live
+ * - Is stable against fresh array references: it keys its effect on the content
+ *   of the address list, so re-renders that pass a new array with the same
+ *   addresses do not churn (unsubscribe/resubscribe) the subscriptions
+ * - Automatically cleans up when the address set changes or the component unmounts
+ *
+ * @param addresses - The account addresses to subscribe to (null/undefined entries are skipped)
+ * @param decoder - Function to decode the account data (must be a stable reference)
+ * @param enabled - Whether the subscriptions should be active
+ *
+ * @example
+ * ```tsx
+ * function Balances({ atas }: { atas: Address[] }) {
+ *   useAccountsSubscription(atas, decodeTokenAccount, true);
+ *   const { data } = useTokenAccounts({ addresses: atas });
+ *   // data updates live as any ATA changes on-chain
+ * }
+ * ```
+ */
+export function useAccountsSubscription<T extends AccountData>(
+  addresses: (Address | null | undefined)[],
+  decoder: AccountDecoder<T> | undefined,
+  enabled: boolean,
+): void {
+  const manager = useSubscriptionManager();
+
+  // Content-stable list of addresses. Keying downstream memos/effects on the
+  // joined string means a fresh array reference with identical contents does
+  // not re-run the subscription effect.
+  const addressesKey = useMemo(
+    () =>
+      addresses.filter((address): address is Address => !!address).join(","),
+    [addresses],
+  );
+  const activeAddresses = useMemo<Address[]>(
+    () => (addressesKey ? (addressesKey.split(",") as Address[]) : []),
+    [addressesKey],
+  );
+
+  useEffect(() => {
+    if (!(enabled && decoder) || activeAddresses.length === 0) {
+      return;
+    }
+
+    const unsubscribes = activeAddresses.map((address) =>
+      manager.subscribe(address, decoder),
+    );
+
+    return () => {
+      for (const unsubscribe of unsubscribes) {
+        unsubscribe();
+      }
+    };
+  }, [manager, activeAddresses, decoder, enabled]);
+}

--- a/packages/grill/src/hooks/use-accounts-subscription.ts
+++ b/packages/grill/src/hooks/use-accounts-subscription.ts
@@ -33,7 +33,7 @@ import { useSubscriptionManager } from "../contexts/subscription-context.js";
  * ```
  */
 export function useAccountsSubscription<T extends AccountData>(
-  addresses: (Address | null | undefined)[],
+  addresses: readonly (Address | null | undefined)[],
   decoder: AccountDecoder<T> | undefined,
   enabled: boolean,
 ): void {

--- a/packages/grill/src/hooks/use-accounts.ts
+++ b/packages/grill/src/hooks/use-accounts.ts
@@ -23,8 +23,11 @@ export type UseAccountsInput<
 > = GillUseRpcHook<TConfig> & {
   /**
    * Addresses of the accounts to get the info of.
+   *
+   * Accepts `null`/`undefined` (treated as an empty list) so the result of a
+   * plural PDA hook such as `useAssociatedTokenPdas` can be passed directly.
    */
-  addresses: (Address | null | undefined)[];
+  addresses: readonly (Address | null | undefined)[] | null | undefined;
   /**
    * Account decoder that can decode the account's `data` byte array value.
    *
@@ -37,12 +40,12 @@ export type UseAccountsResult<TDecodedData extends object> =
   | {
       isLoading: true;
       data: (Account<TDecodedData> | null | undefined)[];
-      addresses: (Address | null | undefined)[];
+      addresses: readonly (Address | null | undefined)[];
     }
   | {
       isLoading: false;
       data: (Account<TDecodedData> | null)[];
-      addresses: (Address | null | undefined)[];
+      addresses: readonly (Address | null | undefined)[];
     };
 
 /**
@@ -75,6 +78,10 @@ export function useAccounts<
 }: UseAccountsInput<TConfig, TDecodedData>): UseAccountsResult<TDecodedData> {
   const { accountLoader } = useGrillContext();
 
+  // Normalize a nullable address list to an array so callers can pass the
+  // result of a plural PDA hook (which may be null/undefined) directly.
+  const addressList = addresses ?? [];
+
   // Memoize the account decoder for subscriptions
   const accountDecoder = useMemo(
     () => createAccountDecoderFromDecoder(decoder),
@@ -83,10 +90,10 @@ export function useAccounts<
 
   // Set up subscriptions if enabled. Writes back to the same account query keys
   // that the queries below read, so results update live.
-  useAccountsSubscription(addresses, accountDecoder, subscribeToUpdates);
+  useAccountsSubscription(addressList, accountDecoder, subscribeToUpdates);
 
   return useQueries({
-    queries: addresses.map((address) => ({
+    queries: addressList.map((address) => ({
       networkMode: "offlineFirst" as const,
       ...options,
       // eslint-disable-next-line @tanstack/query/exhaustive-deps
@@ -103,7 +110,7 @@ export function useAccounts<
         return {
           isLoading: true,
           data: results.map((result) => result.data),
-          addresses,
+          addresses: addressList,
         };
       }
       return {
@@ -111,7 +118,7 @@ export function useAccounts<
         data: results
           .map((result) => result.data)
           .filter((r) => r !== undefined),
-        addresses,
+        addresses: addressList,
       };
     },
   });

--- a/packages/grill/src/hooks/use-accounts.ts
+++ b/packages/grill/src/hooks/use-accounts.ts
@@ -6,10 +6,14 @@ import type {
   Simplify,
 } from "gill";
 import type { GillUseRpcHook } from "./types.js";
+import type { UseAccountOptions } from "./use-account.js";
 import { fetchAndDecodeAccount } from "@macalinao/gill-extra";
 import { useQueries } from "@tanstack/react-query";
+import { useMemo } from "react";
 import { useGrillContext } from "../contexts/grill-context.js";
+import { createAccountDecoderFromDecoder } from "../contexts/subscription-context.js";
 import { createAccountQueryKey } from "../query-keys.js";
+import { useAccountsSubscription } from "./use-accounts-subscription.js";
 
 type RpcConfig = Simplify<Omit<FetchAccountConfig, "abortSignal">>;
 
@@ -27,7 +31,7 @@ export type UseAccountsInput<
    * Note: if not provided, the account will be returned as a `Uint8Array`.
    */
   decoder?: Decoder<TDecodedData>;
-};
+} & UseAccountOptions;
 
 export type UseAccountsResult<TDecodedData extends object> =
   | {
@@ -67,8 +71,20 @@ export function useAccounts<
   options,
   addresses,
   decoder,
+  subscribeToUpdates = false,
 }: UseAccountsInput<TConfig, TDecodedData>): UseAccountsResult<TDecodedData> {
   const { accountLoader } = useGrillContext();
+
+  // Memoize the account decoder for subscriptions
+  const accountDecoder = useMemo(
+    () => createAccountDecoderFromDecoder(decoder),
+    [decoder],
+  );
+
+  // Set up subscriptions if enabled. Writes back to the same account query keys
+  // that the queries below read, so results update live.
+  useAccountsSubscription(addresses, accountDecoder, subscribeToUpdates);
+
   return useQueries({
     queries: addresses.map((address) => ({
       networkMode: "offlineFirst" as const,


### PR DESCRIPTION
## Why

A grill consumer building a live, summed SPL-token balance across several wallets had to hand-roll ~40 lines of subscription glue because grill's plural account hooks are read-once. The singular `useAccount`/`useTokenAccount` accept `subscribeToUpdates`; the plural `useAccounts`/`useTokenAccounts` did not. They also had to re-implement grill's private `Decoder → AccountDecoder` adapter as their own `decodeTokenAccount`, and invent a `join(",")`/`split(",")` "content-key" hack to stop a `useEffect` churning on the fresh array reference `useAssociatedTokenPdas` returns each render.

### Root causes
1. `useAccounts` had no subscription wiring at all (bare `useQueries`), unlike `useAccount` which calls `useAccountSubscription`.
2. `createDecodedAccountsHook`'s input type was `{ addresses }` only — it dropped `UseAccountOptions`, so `useTokenAccounts` could never subscribe.
3. `createAccountDecoderFromDecoder` was a private function inside `use-account.ts`, forcing users of the raw `SubscriptionManager` to reimplement it.
4. No plural subscription hook + unstable array refs → the join/split hack.

## What

- **`useAccounts` / `useTokenAccounts` now accept `subscribeToUpdates`** (threaded through `createDecodedAccountsHook`), mirroring the singular hooks. Writes back to the same account query keys the reads use, so results update live.
- **New `useAccountsSubscription(addresses, decoder, enabled)`** — the plural counterpart to `useAccountSubscription`. It keys its effect on the *content* of the address list, so a fresh array reference with identical addresses doesn't churn subscriptions (absorbs the user's hack into the library). Per-address de-dup/ref-counting is handled by the existing `SubscriptionManager`.
- **Export `createAccountDecoderFromDecoder`** (promoted from `use-account.ts` to `subscription-context.ts) so consumers of the raw subscription manager no longer hand-write the adapter.

The reporter's entire `useSplTokenBalanceQuery` now collapses to:

\`\`\`tsx
const atas = useAssociatedTokenPdas(ataSeeds);
const { data: tokenAccounts, isLoading } = useTokenAccounts({
  addresses: atas ?? [],
  subscribeToUpdates: true,
});
\`\`\`

## Verification

- \`bun run build\` — passes
- \`bun run lint:fix\` — passes (one pre-existing, unrelated example-dapp warning)
- \`bun run test\` — passes (468 tests, all packages)
- Type-checked a snippet mirroring the reporter's collapsed usage against the built package — compiles clean, no manual subscription/decoder/hack needed.

Changeset included (`@macalinao/grill` minor).