### PR TITLE
ci: fail the release when a publish actually fails

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'macalinao'
 
+    env:
+      # changesets commits the version bump, which fires the husky pre-commit hook
+      # and runs lint-staged against the whole release commit. That is a lint gate
+      # on the release, not on the change -- and when it trips, the release dies at
+      # `git commit` with no packages published. CI already lints on the PR.
+      HUSKY: 0
+
     permissions:
       contents: write
       packages: write

--- a/scripts/ci-publish.sh
+++ b/scripts/ci-publish.sh
@@ -11,6 +11,13 @@ set -e
 #
 # Requires: npm >= 11.5.1 and `id-token: write` permission in the workflow, plus
 # a trusted publisher configured for each package on npmjs.com.
+#
+# Every package is packed and published on every run, not just the ones changesets
+# bumped. That is deliberate: a package whose version is already on the registry
+# is simply skipped, so a release that failed to publish half way through is
+# retried and healed by the next run. It does mean "already published" is the
+# normal outcome for most packages, which is why the errors below are classified
+# rather than ignored.
 
 echo "Publishing packages via npm OIDC trusted publishing..."
 
@@ -28,12 +35,54 @@ for dir in packages/*; do
 done
 
 echo "Publishing tarballs to npm..."
+
+published=()
+skipped=()
+failed=()
+
 for tarball in "$PACK_DIR"/*.tgz; do
-  echo "Publishing $(basename "$tarball")..."
-  npm publish "$tarball" --access public || echo "Failed to publish $(basename "$tarball"), continuing..."
+  name="$(basename "$tarball")"
+  echo "Publishing $name..."
+
+  # A non-zero exit is expected for any package changesets did not bump this run,
+  # so the output is captured and classified instead of being discarded. Only an
+  # "already published" error is benign; anything else is a real failure.
+  if output="$(npm publish "$tarball" --access public 2>&1)"; then
+    echo "$output"
+    published+=("$name")
+  elif grep -qF "cannot publish over the previously published versions" <<<"$output"; then
+    echo "  already on the registry, nothing to do"
+    skipped+=("$name")
+  else
+    echo "$output"
+    failed+=("$name")
+  fi
 done
 
-# Tag the release in git
+echo
+echo "published: ${#published[@]}, already up to date: ${#skipped[@]}, failed: ${#failed[@]}"
+for name in "${published[@]}"; do echo "  published  $name"; done
+for name in "${failed[@]}"; do echo "  FAILED     $name"; done
+
+if [ "${#failed[@]}" -gt 0 ]; then
+  cat >&2 <<'EOF'
+
+One or more packages failed to publish.
+
+A 404 from the registry means the OIDC identity was not authorized to publish
+that package. The two usual causes:
+
+  - the package has no trusted publisher configured on npmjs.com, or
+  - the package has never been published at all. OIDC cannot publish a package's
+    first version -- npm requires the package to already exist before a trusted
+    publisher can be attached to it (https://github.com/npm/cli/issues/8544).
+    Publish the first version manually, then configure the trusted publisher.
+EOF
+  exit 1
+fi
+
+# Only tag once every package is actually on the registry, so tags never claim a
+# release that did not happen. A failed run is retried in full by the next one.
 echo "Creating git tags..."
 changeset tag
 


### PR DESCRIPTION
## The bug

`scripts/ci-publish.sh` ran every publish as:

```bash
npm publish "$tarball" --access public || echo "Failed to publish ..., continuing..."
```

The `|| echo` defeats `set -e`, so the release job reported success no matter what happened.

The swallow wasn't gratuitous — the script packs and publishes **every** package on every run, not just the ones changesets bumped, so `You cannot publish over the previously published versions` is the *normal* outcome for most packages and had to be tolerated. But that meant a real failure was indistinguishable from the routine ones.

## It already bit us

`@macalinao/react-quarry@5.0.0` was versioned, changelogged, and git-tagged — but npm's latest is still **4.0.0**. From the release log:

```
Publishing macalinao-react-quarry-5.0.0.tgz...
npm error code E404
npm error 404 The requested resource '@macalinao/react-quarry@5.0.0' could not be
npm error 404 found or you do not have permission to access it.
Failed to publish macalinao-react-quarry-5.0.0.tgz, continuing...
```

A genuine 404 — no trusted publisher was configured for that package — buried among six benign "already published" errors from the same run. The job went green. The changeset was consumed, so nothing would ever retry it.

## The fix

Classify the errors rather than ignore them:

- **already published** → benign, skip
- **anything else** → real failure, report it and `exit 1`

Deliberately kept: publishing every package every run. That's what lets a half-failed release heal itself on the next run — and it means once `react-quarry` has a trusted publisher, the next release picks up and publishes 5.0.0 on its own.

Tagging now happens **only after** every package is confirmed on the registry, so a git tag never claims a release that didn't happen.

On a real failure the script now explains the two causes of a 404 (no trusted publisher, or the package has never been published — OIDC [cannot publish a package's first version](https://github.com/npm/cli/issues/8544)).

## Also: `HUSKY=0` in the release job

Every release run on master is **currently failing**, before publishing anything:

```
× Biome exited because the configuration resulted in errors.
error: "lint-staged" exited with code 1
husky - pre-commit script failed (code 1)
```

changesets commits the version bump, that fires the husky pre-commit hook, and lint-staged runs against the release commit. A lint error there kills the release at `git commit`. CI already lints on the PR; the release commit shouldn't be re-gated on it.

## Verification

Stubbed `npm publish` to exercise all three outcomes:

- new publish + already-published → **exit 0**, tags created
- genuine 404 mixed in → **exit 1**, no tags, diagnostic printed

The second case is precisely the react-quarry scenario that previously passed green.

## Follow-up (not in this PR)

`@macalinao/das-api@0.0.0` and `@macalinao/solana-errors@0.1.0` have now been published manually to break the OIDC chicken-and-egg. **They each need a trusted publisher configured on npmjs.com** (repo `macalinao/grill`, workflow `release.yml`) before CI can publish their bumped versions.