### PR TITLE
chore(lint): strict type-aware oxlint rules

### DIFF
--- a/.changeset/strict-type-aware-lint.md
+++ b/.changeset/strict-type-aware-lint.md
@@ -1,0 +1,19 @@
+---
+"@macalinao/grill": patch
+"@macalinao/gill-extra": patch
+"@macalinao/dataloader-es": patch
+"@macalinao/das-api": patch
+"@macalinao/wallet-adapter-compat": patch
+"@macalinao/react-quarry": patch
+"@macalinao/solana-batch-accounts-loader": patch
+"@macalinao/quarry": patch
+"@macalinao/token-utils": patch
+---
+
+Fix correctness issues surfaced by stricter type-aware lint rules.
+
+- `grill`: `extractErrorLogs` threw a `TypeError` while handling an error whose `context` was `null` (`typeof null === "object"` passed the guard, then `.logs` was read off `null`). It now narrows `context` properly and validates that `logs` really is a `string[]`.
+- `grill`: `createPdaQuery` skipped the PDA computation for any falsy `args`, so a valid falsy seed (`0`, `""`) resolved to `null`. It now only skips when `args` is nullish, matching the `enabled: args !== undefined` guard next to it.
+- `dataloader-es`: `getValidCacheKeyFn` widened the value type to `unknown`, which only typechecked because `CacheMap`'s method shorthand was bivariant. `CacheMap` members are now property signatures (checked contravariantly) and the helper is generic over the value type.
+- `gill-extra`, `grill`: transaction `err` fields are `TransactionError | null`, so they are now compared against `null` instead of tested for truthiness.
+- `das-api`, `wallet-adapter-compat`, `dataloader-es`, `grill`: interface members that are functions are declared as property signatures rather than method shorthand, so their parameters are checked contravariantly.

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -52,10 +52,102 @@
     "typescript/related-getter-setter-pairs": "error",
     "typescript/require-await": "error",
     "typescript/restrict-plus-operands": "error",
-    "typescript/restrict-template-expressions": "error",
+    // oxlint's defaults for this rule are much looser than
+    // typescript-eslint's: allowAny, allowBoolean, allowNullish and allowRegExp
+    // all default to `true`, so `${maybeUndefined}` and `${someAny}` pass. Only
+    // `allowNumber` is kept -- `${count}` is everywhere and unambiguous.
+    "typescript/restrict-template-expressions": [
+      "error",
+      {
+        "allowAny": false,
+        "allowArray": false,
+        "allowBoolean": false,
+        "allowNever": false,
+        "allowNullish": false,
+        "allowNumber": true,
+        "allowRegExp": false
+      }
+    ],
     "typescript/return-await": "error",
+    // A `default:` case no longer excuses a switch from covering every union
+    // member, and non-union switches must have a `default:`.
+    "typescript/switch-exhaustiveness-check": [
+      "error",
+      {
+        "considerDefaultExhaustiveForUnions": true,
+        "requireDefaultForNonUnion": true
+      }
+    ],
     "typescript/unbound-method": "error",
     "typescript/use-unknown-in-catch-callback-variable": "error",
+
+    // Type-aware rules beyond typescript-eslint's strict-type-checked preset.
+    //
+    // strict-boolean-expressions runs with the nullable-primitive escapes on:
+    // `if (maybeName)`, `if (flag)` and `if (arr?.length)` are the dominant
+    // idiom in this repo and rewriting them to `!= null && !== ""` is churn
+    // without a behaviour change. What is left on is the part that catches real
+    // problems: `any`/`unknown` in a condition (allowAny stays false),
+    // always-truthy objects, and unions whose members disagree about
+    // truthiness (`string | number`, `string | object | null`).
+    "typescript/strict-boolean-expressions": [
+      "error",
+      {
+        "allowAny": false,
+        "allowNullableBoolean": true,
+        "allowNullableEnum": true,
+        "allowNullableNumber": true,
+        "allowNullableString": true
+      }
+    ],
+    "typescript/strict-void-return": "error",
+    "typescript/no-deprecated": "error",
+    "typescript/consistent-type-exports": "error",
+    "typescript/prefer-readonly": "error",
+    "typescript/require-array-sort-compare": "error",
+    "typescript/no-unnecessary-qualifier": "error",
+    "typescript/no-unnecessary-parameter-property-assignment": "error",
+    "typescript/no-useless-default-assignment": "error",
+    // Method shorthand (`foo(x: T): void`) is bivariant in its parameters;
+    // property style (`foo: (x: T) => void`) is checked contravariantly.
+    "typescript/method-signature-style": "error",
+
+    // Syntax-level TypeScript rules. None of these had a violation when they
+    // were turned on -- they are here to keep it that way.
+    "typescript/adjacent-overload-signatures": "error",
+    "typescript/ban-ts-comment": "error",
+    "typescript/ban-tslint-comment": "error",
+    "typescript/class-literal-property-style": "error",
+    "typescript/consistent-generic-constructors": "error",
+    "typescript/consistent-indexed-object-style": "error",
+    "typescript/consistent-type-assertions": "error",
+    "typescript/no-confusing-non-null-assertion": "error",
+    "typescript/no-duplicate-enum-values": "error",
+    "typescript/no-dynamic-delete": "error",
+    "typescript/no-empty-object-type": "error",
+    "typescript/no-extra-non-null-assertion": "error",
+    "typescript/no-extraneous-class": "error",
+    "typescript/no-import-type-side-effects": "error",
+    "typescript/no-invalid-void-type": "error",
+    "typescript/no-misused-new": "error",
+    "typescript/no-namespace": "error",
+    "typescript/no-non-null-asserted-nullish-coalescing": "error",
+    "typescript/no-non-null-asserted-optional-chain": "error",
+    "typescript/no-require-imports": "error",
+    "typescript/no-this-alias": "error",
+    "typescript/no-unnecessary-type-constraint": "error",
+    "typescript/no-unsafe-declaration-merging": "error",
+    "typescript/no-unsafe-function-type": "error",
+    "typescript/no-useless-empty-export": "error",
+    "typescript/no-wrapper-object-types": "error",
+    "typescript/prefer-for-of": "error",
+    "typescript/prefer-function-type": "error",
+    "typescript/prefer-literal-enum-member": "error",
+    "typescript/prefer-namespace-keyword": "error",
+    "typescript/prefer-ts-expect-error": "error",
+    "typescript/triple-slash-reference": "error",
+    "typescript/unified-signatures": "error",
+
     "typescript/dot-notation": "error",
     "typescript/non-nullable-type-assertion-style": "error",
     "typescript/prefer-find": "error",
@@ -96,7 +188,7 @@
     "typescript/no-inferrable-types": "error", // style/noInferrableTypes
     "typescript/no-non-null-assertion": "error", // style/noNonNullAssertion (Biome recommended)
     "typescript/no-explicit-any": "error", // suspicious/noExplicitAny (Biome recommended)
-    "typescript/no-unused-vars": "warn", // correctness/noUnusedVariables (Biome had this at warn)
+    "typescript/no-unused-vars": "error", // correctness/noUnusedVariables (Biome had this at warn)
     "unicorn/prefer-number-properties": "error", // style/useNumberNamespace
     "unicorn/no-document-cookie": "error", // suspicious/noDocumentCookie (Biome recommended)
     "react/self-closing-comp": "error", // style/useSelfClosingElements
@@ -120,7 +212,44 @@
     //   style/useSingleVarDeclarator -- oxlint has no `one-var`.
     //   complexity/useSimplifiedLogicExpression -- no equivalent.
     //   style/noUnusedTemplateLiteral -- no equivalent.
-    "react/only-export-components": "warn" // style/useComponentExportOnlyModules (biome-config/react had this at warn)
+    "react/only-export-components": "error", // style/useComponentExportOnlyModules
+
+    // Type-aware rules considered and deliberately left OFF. Counts are the
+    // violations each produced against this tree; re-check before enabling.
+    //
+    //   typescript/prefer-readonly-parameter-types (346) -- would require
+    //     `readonly` on essentially every parameter, including React props and
+    //     @solana/kit's own types, which are not declared readonly. Noise.
+    //
+    //   typescript/explicit-function-return-type (111) and
+    //   typescript/explicit-module-boundary-types (60) -- 91 of the 111 are
+    //     React components in example-dapp, where `: JSX.Element` adds nothing.
+    //     The published surface is already covered: `isolatedDeclarations` is
+    //     on in every packages/* project and forces return types on exports.
+    //
+    //   typescript/no-unsafe-type-assertion (57) -- every hit is a load-bearing
+    //     narrowing cast that the domain requires: branded types (`as Address`,
+    //     `as Signature`, `as SignatureBytes`), dnum tuples
+    //     (`as readonly [bigint, TDecimals]`), and decoder generics
+    //     (`as Account<TDecodedData>`). The only way to satisfy it is
+    //     `as unknown as T`, which is strictly worse. typescript-eslint ships
+    //     this rule in no preset for the same reason.
+    //
+    //   typescript/promise-function-async (39) -- 31 are in dataloader-es,
+    //     where adding `async` to functions that already return a promise
+    //     inserts an extra microtask. Batch scheduling there is timing
+    //     sensitive; the churn carries risk and buys nothing.
+    //
+    //   typescript/consistent-return (2) -- both hits are `useEffect` callbacks
+    //     that return a cleanup on one path and bare `return;` on another,
+    //     which is the documented React idiom. The rule would force
+    //     `return undefined;`.
+    "typescript/prefer-readonly-parameter-types": "off",
+    "typescript/explicit-function-return-type": "off",
+    "typescript/explicit-module-boundary-types": "off",
+    "typescript/no-unsafe-type-assertion": "off",
+    "typescript/promise-function-async": "off",
+    "typescript/consistent-return": "off"
   },
   // Mirrors the per-path overrides that lived in apps/example-dapp/biome.jsonc.
   "overrides": [

--- a/apps/example-dapp/src/components/ui/sidebar.tsx
+++ b/apps/example-dapp/src/components/ui/sidebar.tsx
@@ -530,7 +530,7 @@ function SidebarMenuButton({
     />
   );
 
-  if (!tooltip) {
+  if (tooltip === undefined || tooltip === "") {
     return button;
   }
 

--- a/apps/example-dapp/src/hooks/use-theme.ts
+++ b/apps/example-dapp/src/hooks/use-theme.ts
@@ -9,7 +9,9 @@ export interface ThemeProviderState {
 
 const initialState: ThemeProviderState = {
   theme: "system",
-  setTheme: () => null,
+  setTheme: () => {
+    // Replaced by ThemeProvider; a bare context read is a no-op.
+  },
 };
 
 export const ThemeProviderContext =

--- a/apps/example-dapp/src/routes/examples/transfer-sol.tsx
+++ b/apps/example-dapp/src/routes/examples/transfer-sol.tsx
@@ -130,14 +130,11 @@ const TransferSolPage: React.FC = () => {
       amount: lamports(parsedAmount.amount[0]),
     });
 
-    const signature = await sendTX(`Transfer ${amount.toString()} SOL`, [
-      instruction,
-    ]);
+    // sendTX throws if the transaction does not land.
+    await sendTX(`Transfer ${amount.toString()} SOL`, [instruction]);
 
-    if (signature) {
-      // Clear form after successful transaction
-      reset();
-    }
+    // Clear form after successful transaction
+    reset();
   };
 
   if (!signer) {

--- a/apps/example-dapp/tsconfig.json
+++ b/apps/example-dapp/tsconfig.json
@@ -2,7 +2,10 @@
   // Extends tsconfig.react.json rather than tsconfig.vite.json because the latter
   // still sets `baseUrl`, which TypeScript 7 removes and tsgolint (used by
   // `oxlint --type-aware`) rejects. The vite-specific options are inlined below.
-  "extends": ["@macalinao/tsconfig/tsconfig.react.json"],
+  "extends": [
+    "@macalinao/tsconfig/tsconfig.react.json",
+    "../../tsconfig.strict.json"
+  ],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "module": "ESNext",

--- a/packages/das-api/src/das-api.ts
+++ b/packages/das-api/src/das-api.ts
@@ -33,33 +33,35 @@ import { dasApiResponseTransformer } from "./response-transformer.js";
  */
 export interface SolanaDasApi {
   /** Get a single asset by its id. */
-  getAsset(input: GetAssetRequest): DasApiAsset;
+  getAsset: (input: GetAssetRequest) => DasApiAsset;
   /** Get multiple assets by their ids. */
-  getAssetBatch(input: GetAssetBatchRequest): (DasApiAsset | null)[];
+  getAssetBatch: (input: GetAssetBatchRequest) => (DasApiAsset | null)[];
   /** Get a merkle proof for a compressed asset. */
-  getAssetProof(input: GetAssetProofRequest): GetAssetProofResponse;
+  getAssetProof: (input: GetAssetProofRequest) => GetAssetProofResponse;
   /** Get merkle proofs for multiple compressed assets. */
-  getAssetProofBatch(
+  getAssetProofBatch: (
     input: GetAssetProofBatchRequest,
-  ): GetAssetProofBatchResponse;
+  ) => GetAssetProofBatchResponse;
   /** Get a paginated list of assets owned by an address. */
-  getAssetsByOwner(input: GetAssetsByOwnerRequest): DasApiAssetList;
+  getAssetsByOwner: (input: GetAssetsByOwnerRequest) => DasApiAssetList;
   /** Get a paginated list of assets controlled by an authority. */
-  getAssetsByAuthority(input: GetAssetsByAuthorityRequest): DasApiAssetList;
+  getAssetsByAuthority: (input: GetAssetsByAuthorityRequest) => DasApiAssetList;
   /** Get a paginated list of assets created by an address. */
-  getAssetsByCreator(input: GetAssetsByCreatorRequest): DasApiAssetList;
+  getAssetsByCreator: (input: GetAssetsByCreatorRequest) => DasApiAssetList;
   /** Get a paginated list of assets belonging to a group. */
-  getAssetsByGroup(input: GetAssetsByGroupRequest): DasApiAssetList;
+  getAssetsByGroup: (input: GetAssetsByGroupRequest) => DasApiAssetList;
   /** Search for assets matching a set of criteria. */
-  searchAssets(input: SearchAssetsRequest): DasApiAssetList;
+  searchAssets: (input: SearchAssetsRequest) => DasApiAssetList;
   /** Get the transaction signatures associated with an asset. */
-  getSignaturesForAsset(
+  getSignaturesForAsset: (
     input: GetSignaturesForAssetRequest,
-  ): GetSignaturesForAssetResponse;
+  ) => GetSignaturesForAssetResponse;
   /** Get token accounts by owner and/or mint (Helius extension). */
-  getTokenAccounts(input: GetTokenAccountsRequest): GetTokenAccountsResponse;
+  getTokenAccounts: (
+    input: GetTokenAccountsRequest,
+  ) => GetTokenAccountsResponse;
   /** Get the printed editions of a master edition NFT (Helius extension). */
-  getNftEditions(input: GetNftEditionsRequest): GetNftEditionsResponse;
+  getNftEditions: (input: GetNftEditionsRequest) => GetNftEditionsResponse;
 }
 
 /**

--- a/packages/das-api/src/schemas/asset.test.ts
+++ b/packages/das-api/src/schemas/asset.test.ts
@@ -265,7 +265,7 @@ describe("dasApiAssetSchema", () => {
     expect(asset.inscription?.inscriptionDataAccount).toBe(
       address(SYSTEM_PROGRAM),
     );
-    expect(asset.spl20?.tick).toBe("test");
+    expect(asset.spl20?.["tick"]).toBe("test");
     expect(asset.last_indexed_slot).toBe(123_456_789);
     expect(asset.mpl_core_info?.num_minted).toBe(10);
   });

--- a/packages/das-api/src/schemas/json-value.test.ts
+++ b/packages/das-api/src/schemas/json-value.test.ts
@@ -55,8 +55,8 @@ describe("jsonObjectSchema", () => {
       object: { nested: true },
     });
 
-    expect(parsed.string).toBe("s");
-    expect(parsed.object).toEqual({ nested: true });
+    expect(parsed["string"]).toBe("s");
+    expect(parsed["object"]).toEqual({ nested: true });
   });
 
   it("rejects non-objects", () => {

--- a/packages/das-api/src/schemas/token-accounts.test.ts
+++ b/packages/das-api/src/schemas/token-accounts.test.ts
@@ -43,7 +43,7 @@ describe("dasApiTokenAccountSchema", () => {
     expect(account.delegated_amount).toBe(500);
     expect(account.delegate).toBe(address(DELEGATE));
     expect(account.close_authority).toBe(address(OWNER));
-    expect(account.token_extensions?.transfer_fee_amount).toEqual({
+    expect(account.token_extensions?.["transfer_fee_amount"]).toEqual({
       withheld_amount: 0,
     });
   });

--- a/packages/das-api/tsconfig.json
+++ b/packages/das-api/tsconfig.json
@@ -1,7 +1,9 @@
 {
-  "extends": "@macalinao/tsconfig/tsconfig.base.json",
+  "extends": [
+    "@macalinao/tsconfig/tsconfig.base.json",
+    "../../tsconfig.strict.json"
+  ],
   "compilerOptions": {
-    "isolatedDeclarations": false,
     "types": ["bun"],
     "composite": false,
     "incremental": false

--- a/packages/dataloader-es/src/dataLoader.test.ts
+++ b/packages/dataloader-es/src/dataLoader.test.ts
@@ -137,14 +137,18 @@ describe("Primary API", () => {
     });
 
     // Move to next tick
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
 
     expect(promise1Resolved).toBe(false);
     expect(promise2Resolved).toBe(false);
 
     resolveBatch();
     // Move to next tick
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
 
     expect(promise1Resolved).toBe(true);
     expect(promise2Resolved).toBe(true);
@@ -189,7 +193,9 @@ describe("Primary API", () => {
     });
 
     // Move to next tick
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
 
     // Promise 1 resolves first since max batch size is 1,
     // but it still hasn't resolved yet.
@@ -198,7 +204,9 @@ describe("Primary API", () => {
 
     resolveBatch();
     // Move to next tick
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
 
     expect(promise1Resolved).toBe(true);
     expect(promise2Resolved).toBe(true);
@@ -511,7 +519,9 @@ describe("Represents Errors", () => {
     identityLoader.prime(1, new Error("Error: 1"));
 
     // Wait a bit.
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
 
     let caughtErrorA: unknown;
     try {

--- a/packages/dataloader-es/src/dataLoader.ts
+++ b/packages/dataloader-es/src/dataLoader.ts
@@ -13,11 +13,11 @@ import type { Batch, BatchLoadFn, CacheMap, Options } from "./types.js";
  */
 export class DataLoader<K, V, C = K> {
   // Private
-  #batchLoadFn: BatchLoadFn<K, V>;
-  #maxBatchSize: number;
-  #batchScheduleFn: (callback: () => void) => void;
-  #cacheKeyFn: (key: K) => C;
-  #cacheMap: CacheMap<C, Promise<V>> | null;
+  readonly #batchLoadFn: BatchLoadFn<K, V>;
+  readonly #maxBatchSize: number;
+  readonly #batchScheduleFn: (callback: () => void) => void;
+  readonly #cacheKeyFn: (key: K) => C;
+  readonly #cacheMap: CacheMap<C, Promise<V>> | null;
   #batch: Batch<K, V> | null;
 
   /**
@@ -269,14 +269,16 @@ function getValidBatchScheduleFn<K, V, C>(
   const batchScheduleFn = options?.batchScheduleFn;
   if (batchScheduleFn === undefined) {
     // Unlike the original DataLoader, we assume `setTimeout` is available.
-    return (cb) => setTimeout(cb, 0);
+    return (cb) => {
+      setTimeout(cb, 0);
+    };
   }
   return batchScheduleFn;
 }
 
 // Private: given the DataLoader's options, produce a cache key function.
-function getValidCacheKeyFn<K, C>(
-  options?: Options<K, unknown, C>,
+function getValidCacheKeyFn<K, V, C>(
+  options?: Options<K, V, C>,
 ): (key: K) => C {
   const cacheKeyFn = options?.cacheKeyFn;
   if (cacheKeyFn === undefined) {

--- a/packages/dataloader-es/src/types.ts
+++ b/packages/dataloader-es/src/types.ts
@@ -56,10 +56,10 @@ export interface Options<K, V, C = K> {
 
 // If a custom cache is provided, it must be of this type (a subset of ES6 Map).
 export interface CacheMap<K, V> {
-  get(key: K): V | undefined;
-  set(key: K, value: V): void;
-  delete(key: K): void;
-  clear(): void;
+  get: (key: K) => V | undefined;
+  set: (key: K, value: V) => void;
+  delete: (key: K) => void;
+  clear: () => void;
 }
 
 // Private: Describes a batch of requests

--- a/packages/dataloader-es/tsconfig.json
+++ b/packages/dataloader-es/tsconfig.json
@@ -1,5 +1,8 @@
 {
-  "extends": "@macalinao/tsconfig/tsconfig.dom.json",
+  "extends": [
+    "@macalinao/tsconfig/tsconfig.dom.json",
+    "../../tsconfig.strict.json"
+  ],
   "compilerOptions": {
     "types": ["bun"],
     "composite": false,

--- a/packages/gill-extra/src/index.ts
+++ b/packages/gill-extra/src/index.ts
@@ -16,4 +16,4 @@ export * from "./log-transaction-simulation.js";
 export * from "./poll-confirm-transaction.js";
 export * from "./transaction.js";
 export * from "./transaction-error.js";
-export * from "./types.js";
+export type * from "./types.js";

--- a/packages/gill-extra/src/poll-confirm-transaction.ts
+++ b/packages/gill-extra/src/poll-confirm-transaction.ts
@@ -42,7 +42,7 @@ export async function pollConfirmTransaction({
           status.confirmationStatus === "finalized"
         ) {
           confirmed = true;
-          if (status.err) {
+          if (status.err !== null) {
             confirmationError = new Error("Transaction failed on-chain");
           }
           break;
@@ -56,7 +56,9 @@ export async function pollConfirmTransaction({
       }
 
       // Wait before next attempt
-      await new Promise((resolve) => setTimeout(resolve, retryInterval));
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, retryInterval);
+      });
       retries++;
     } catch (error) {
       console.error("Error checking transaction status:", error);

--- a/packages/gill-extra/tsconfig.json
+++ b/packages/gill-extra/tsconfig.json
@@ -1,6 +1,16 @@
 {
-  "extends": "@macalinao/tsconfig/tsconfig.base.json",
+  "extends": [
+    "@macalinao/tsconfig/tsconfig.base.json",
+    "../../tsconfig.strict.json"
+  ],
   "compilerOptions": {
+    // The one package that still opts out of isolatedDeclarations.
+    // `getConfirmedTransaction` returns whatever
+    // `rpc.getTransaction(sig, { encoding: "jsonParsed", ... }).send()` returns,
+    // and `GetTransactionApi["getTransaction"]` is a four-way overload keyed on
+    // `encoding`. There is no sound way to name that type by hand:
+    // `ReturnType<>` resolves to the last overload (`encoding: "json"`), which
+    // is the wrong one. Inference is the only thing that gets it right.
     "isolatedDeclarations": false,
     "types": ["bun"],
     "composite": false,

--- a/packages/grill/src/contexts/subscription-context.ts
+++ b/packages/grill/src/contexts/subscription-context.ts
@@ -90,15 +90,15 @@ export interface SubscriptionManager {
    * Multiple calls with the same address will share a single WebSocket subscription.
    * The subscription is automatically cleaned up when all subscribers unsubscribe.
    */
-  subscribe<T extends AccountData>(
+  subscribe: <T extends AccountData>(
     address: Address,
     decoder: AccountDecoder<T>,
-  ): () => void;
+  ) => () => void;
 
   /**
    * Get the current reference count for an address (for debugging).
    */
-  getSubscriptionCount(address: Address): number;
+  getSubscriptionCount: (address: Address) => number;
 }
 
 /**

--- a/packages/grill/src/hooks/pda-query-utils.ts
+++ b/packages/grill/src/hooks/pda-query-utils.ts
@@ -13,7 +13,9 @@ export function createPdaQuery<TArgs, TResult>(
   return {
     queryKey: createPdaQueryKey(queryKeyPrefix, args),
     queryFn: async () => {
-      if (!args) {
+      // Nullish, not falsy: TArgs is unconstrained, so a falsy-but-valid seed
+      // (0, "") must still be passed through to pdaFn.
+      if (args === null || args === undefined) {
         return null;
       }
       const [pda] = await pdaFn(args);

--- a/packages/grill/src/index.ts
+++ b/packages/grill/src/index.ts
@@ -6,5 +6,5 @@ export * from "./hooks/index.js";
 export * from "./pdas/index.js";
 export * from "./providers/index.js";
 export * from "./query-keys.js";
-export * from "./types.js";
+export type * from "./types.js";
 export * from "./utils/index.js";

--- a/packages/grill/src/providers/grill-provider.tsx
+++ b/packages/grill/src/providers/grill-provider.tsx
@@ -71,7 +71,7 @@ export const GrillProvider: FC<GrillProviderProps> = ({
       switch (event.type) {
         case "error-wallet-not-connected": {
           // Clean up any existing toast
-          if (existingToastId) {
+          if (existingToastId !== undefined) {
             toast.dismiss(existingToastId);
             toastIds.current.delete(txId);
           }
@@ -86,7 +86,7 @@ export const GrillProvider: FC<GrillProviderProps> = ({
           console.error("Error sending transaction", event);
           const description = event.errorMessage;
 
-          if (existingToastId) {
+          if (existingToastId !== undefined) {
             // Update existing toast to error
             toast.error(event.title, {
               id: existingToastId,
@@ -107,7 +107,7 @@ export const GrillProvider: FC<GrillProviderProps> = ({
 
         case "preparing": {
           // Clean up any existing toast for this transaction
-          if (existingToastId) {
+          if (existingToastId !== undefined) {
             toast.dismiss(existingToastId);
             toastIds.current.delete(txId);
           }
@@ -122,7 +122,7 @@ export const GrillProvider: FC<GrillProviderProps> = ({
           // Update existing toast or create new one
           const description = "Please approve in your wallet";
 
-          if (existingToastId) {
+          if (existingToastId !== undefined) {
             toast.loading(event.title, {
               id: existingToastId,
               description,
@@ -141,7 +141,7 @@ export const GrillProvider: FC<GrillProviderProps> = ({
           const description = `Transaction: ${event.sig.slice(0, 8)}...${event.sig.slice(-8)}`;
           const action = createExplorerAction(event.explorerLink);
 
-          if (existingToastId) {
+          if (existingToastId !== undefined) {
             toast.loading(event.title, {
               id: existingToastId,
               description,
@@ -163,7 +163,7 @@ export const GrillProvider: FC<GrillProviderProps> = ({
 
           console.log({ event, existingToastId, description, action });
 
-          if (existingToastId) {
+          if (existingToastId !== undefined) {
             // Update existing toast to success
             toast.success(event.title, {
               id: existingToastId,
@@ -189,7 +189,7 @@ export const GrillProvider: FC<GrillProviderProps> = ({
           const description = event.errorMessage;
           const action = createExplorerAction(event.explorerLink);
 
-          if (existingToastId) {
+          if (existingToastId !== undefined) {
             // Update existing toast to error
             toast.error(event.title, {
               id: existingToastId,
@@ -212,7 +212,7 @@ export const GrillProvider: FC<GrillProviderProps> = ({
         case "error-simulation-failed": {
           console.error("Simulation failed", event);
           const description = `Simulation failed: ${event.errorMessage}`;
-          if (existingToastId) {
+          if (existingToastId !== undefined) {
             // Update existing toast to error
             toast.error(event.title, {
               id: existingToastId,

--- a/packages/grill/src/utils/internal/create-send-tx.ts
+++ b/packages/grill/src/utils/internal/create-send-tx.ts
@@ -109,7 +109,7 @@ export const createSendTX = ({
       const simulationResult = await simulateTransaction(
         finalTransactionMessage,
       );
-      if (simulationResult.value.err) {
+      if (simulationResult.value.err !== null) {
         // Log detailed debugging information to the console
         logTransactionSimulation({
           title: name,
@@ -207,24 +207,26 @@ export const createSendTX = ({
       console.error(`${name} transaction failed:`, error);
 
       // Extract error logs
+      const isLogs = (value: unknown): value is string[] =>
+        Array.isArray(value) && value.every((line) => typeof line === "string");
+
       const extractErrorLogs = (err: unknown): string[] => {
-        if (
-          err &&
-          typeof err === "object" &&
-          "logs" in err &&
-          Array.isArray(err.logs)
-        ) {
-          return (err as { logs: string[] }).logs;
+        if (typeof err !== "object" || err === null) {
+          return [];
         }
-        if (
-          err &&
-          typeof err === "object" &&
-          "context" in err &&
-          typeof err.context === "object" &&
-          (err as { context: { logs?: unknown } }).context.logs &&
-          Array.isArray((err as { context: { logs: unknown } }).context.logs)
-        ) {
-          return (err as { context: { logs: string[] } }).context.logs;
+        if ("logs" in err && isLogs(err.logs)) {
+          return err.logs;
+        }
+        if ("context" in err) {
+          const { context } = err;
+          if (
+            typeof context === "object" &&
+            context !== null &&
+            "logs" in context &&
+            isLogs(context.logs)
+          ) {
+            return context.logs;
+          }
         }
         return [];
       };

--- a/packages/grill/tsconfig.json
+++ b/packages/grill/tsconfig.json
@@ -1,5 +1,8 @@
 {
-  "extends": "@macalinao/tsconfig/tsconfig.react.json",
+  "extends": [
+    "@macalinao/tsconfig/tsconfig.react.json",
+    "../../tsconfig.strict.json"
+  ],
   "compilerOptions": {
     "types": ["bun"],
     "composite": false,

--- a/packages/quarry/src/ixs/merge-miner/claim/index.ts
+++ b/packages/quarry/src/ixs/merge-miner/claim/index.ts
@@ -5,4 +5,4 @@ export * from "./claim-primary-rewards.js";
 export * from "./claim-primary-rewards-no-withdraw.js";
 export * from "./claim-replica-rewards.js";
 export * from "./claim-replica-rewards-no-withdraw.js";
-export * from "./types.js";
+export type * from "./types.js";

--- a/packages/quarry/src/ixs/merge-miner/index.ts
+++ b/packages/quarry/src/ixs/merge-miner/index.ts
@@ -5,4 +5,4 @@ export * from "./helpers.js";
 export * from "./init/index.js";
 export * from "./miner.js";
 export * from "./rescue.js";
-export * from "./types.js";
+export type * from "./types.js";

--- a/packages/quarry/tsconfig.json
+++ b/packages/quarry/tsconfig.json
@@ -1,5 +1,8 @@
 {
-  "extends": "@macalinao/tsconfig/tsconfig.base.json",
+  "extends": [
+    "@macalinao/tsconfig/tsconfig.base.json",
+    "../../tsconfig.strict.json"
+  ],
   "compilerOptions": {
     "types": ["bun"],
     "composite": false,

--- a/packages/react-quarry/src/hooks/use-quarry-claim-mm.ts
+++ b/packages/react-quarry/src/hooks/use-quarry-claim-mm.ts
@@ -104,7 +104,8 @@ export const useQuarryClaimMM = (): UseQuarryClaimMMResult => {
     sendTX,
   ]);
 
-  const isReady = !!signer && !!mergePool;
+  // mergePool is always present -- useMergeMinerContext throws without it.
+  const isReady = signer !== null;
 
   return {
     claimAll,

--- a/packages/react-quarry/src/hooks/use-quarry-deposit-mm.ts
+++ b/packages/react-quarry/src/hooks/use-quarry-deposit-mm.ts
@@ -49,7 +49,8 @@ export const useQuarryDepositMM = (): UseQuarryDepositMMResult => {
     ],
   );
 
-  const isReady = !!signer && !!mergePool;
+  // mergePool is always present -- useMergeMinerContext throws without it.
+  const isReady = signer !== null;
 
   return {
     deposit,

--- a/packages/react-quarry/src/hooks/use-quarry-withdraw-mm.ts
+++ b/packages/react-quarry/src/hooks/use-quarry-withdraw-mm.ts
@@ -52,7 +52,8 @@ export const useQuarryWithdrawMM = (): UseQuarryWithdrawMMResult => {
     ],
   );
 
-  const isReady = !!signer && !!mergePool;
+  // mergePool is always present -- useMergeMinerContext throws without it.
+  const isReady = signer !== null;
 
   return {
     withdraw,

--- a/packages/react-quarry/tsconfig.json
+++ b/packages/react-quarry/tsconfig.json
@@ -1,5 +1,8 @@
 {
-  "extends": "@macalinao/tsconfig/tsconfig.react.json",
+  "extends": [
+    "@macalinao/tsconfig/tsconfig.react.json",
+    "../../tsconfig.strict.json"
+  ],
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",

--- a/packages/solana-batch-accounts-loader/src/createBatchAccountsLoader.ts
+++ b/packages/solana-batch-accounts-loader/src/createBatchAccountsLoader.ts
@@ -68,7 +68,9 @@ export function createBatchAccountsLoader({
       ).flat();
     },
     {
-      batchScheduleFn: (callback) => setTimeout(callback, batchDurationMs),
+      batchScheduleFn: (callback) => {
+        setTimeout(callback, batchDurationMs);
+      },
       maxBatchSize,
     },
   );

--- a/packages/solana-batch-accounts-loader/src/index.ts
+++ b/packages/solana-batch-accounts-loader/src/index.ts
@@ -1,2 +1,2 @@
 export { createBatchAccountsLoader } from "./createBatchAccountsLoader.js";
-export * from "./types.js";
+export type * from "./types.js";

--- a/packages/solana-batch-accounts-loader/tsconfig.json
+++ b/packages/solana-batch-accounts-loader/tsconfig.json
@@ -1,5 +1,8 @@
 {
-  "extends": "@macalinao/tsconfig/tsconfig.base.json",
+  "extends": [
+    "@macalinao/tsconfig/tsconfig.base.json",
+    "../../tsconfig.strict.json"
+  ],
   "compilerOptions": {
     "types": ["bun"],
     "composite": false,

--- a/packages/solana-errors/tsconfig.json
+++ b/packages/solana-errors/tsconfig.json
@@ -1,7 +1,9 @@
 {
-  "extends": "@macalinao/tsconfig/tsconfig.base.json",
+  "extends": [
+    "@macalinao/tsconfig/tsconfig.base.json",
+    "../../tsconfig.strict.json"
+  ],
   "compilerOptions": {
-    "isolatedDeclarations": false,
     "types": ["bun"],
     "composite": false,
     "incremental": false

--- a/packages/token-utils/src/index.ts
+++ b/packages/token-utils/src/index.ts
@@ -7,4 +7,4 @@ export * from "./native-sol.js";
 export * from "./parse-token-amount.js";
 export * as tmath from "./tmath.js";
 export * from "./token-amount-to-bigint.js";
-export * from "./types.js";
+export type * from "./types.js";

--- a/packages/token-utils/tsconfig.json
+++ b/packages/token-utils/tsconfig.json
@@ -1,5 +1,8 @@
 {
-  "extends": "@macalinao/tsconfig/tsconfig.base.json",
+  "extends": [
+    "@macalinao/tsconfig/tsconfig.base.json",
+    "../../tsconfig.strict.json"
+  ],
   "compilerOptions": {
     "types": ["bun"],
     "composite": false,

--- a/packages/wallet-adapter-compat/src/wallet-transaction-sending-signer.ts
+++ b/packages/wallet-adapter-compat/src/wallet-transaction-sending-signer.ts
@@ -23,13 +23,13 @@ import {
 export interface WalletAdapter {
   publicKey: PublicKey | null;
   supportedTransactionVersions?: SupportedTransactionVersions;
-  sendTransaction(
+  sendTransaction: (
     transaction: TransactionOrVersionedTransaction<
       this["supportedTransactionVersions"]
     >,
     connection: Connection,
     options?: SendTransactionOptions,
-  ): Promise<TransactionSignature>;
+  ) => Promise<TransactionSignature>;
 }
 
 /**

--- a/packages/wallet-adapter-compat/tsconfig.json
+++ b/packages/wallet-adapter-compat/tsconfig.json
@@ -1,5 +1,8 @@
 {
-  "extends": "@macalinao/tsconfig/tsconfig.react.json",
+  "extends": [
+    "@macalinao/tsconfig/tsconfig.react.json",
+    "../../tsconfig.strict.json"
+  ],
   "compilerOptions": {
     "composite": false,
     "incremental": false

--- a/packages/zod-solana/tsconfig.json
+++ b/packages/zod-solana/tsconfig.json
@@ -1,5 +1,8 @@
 {
-  "extends": "@macalinao/tsconfig/tsconfig.base.json",
+  "extends": [
+    "@macalinao/tsconfig/tsconfig.base.json",
+    "../../tsconfig.strict.json"
+  ],
   "compilerOptions": {
     "types": ["bun"],
     "composite": false,

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig.json",
+  // Strictness layered on top of @macalinao/tsconfig, which already enables
+  // `strict`, `noUncheckedIndexedAccess`, `noUnusedLocals`, `noUnusedParameters`,
+  // `noImplicitOverride`, `noFallthroughCasesInSwitch` and `isolatedDeclarations`.
+  //
+  // Every package extends this as the second entry of its `extends` array, so
+  // these win over the base config. Anything listed here is enforced repo-wide.
+  //
+  // `exactOptionalPropertyTypes` is deliberately NOT here: it does not survive
+  // contact with @tanstack/react-query's option objects (`placeholderData`,
+  // `enabled`), which would have to be passed via conditional spreads. See the
+  // PR that introduced this file for the full breakdown.
+  "compilerOptions": {
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+    "erasableSyntaxOnly": true,
+    "noImplicitReturns": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noUncheckedSideEffectImports": true
+  }
+}


### PR DESCRIPTION
Turns on the type-aware rules beyond typescript-eslint's `strict-type-checked` preset that this codebase can realistically satisfy, tightens the tsconfig strictness that `@macalinao/tsconfig` leaves off, and fixes the resulting violations. No rule was blanket-disabled and no `any` was added.

## Real bugs the new rules caught

**`grill` — `extractErrorLogs` threw a `TypeError` while handling an error.** The guard was `typeof err.context === "object"`, which is also true for `null`, and the next clause read `.context.logs` off it. An error carrying `context: null` crashed the error handler. `strict-boolean-expressions` flagged the `unknown` in the condition, which is what exposed it. The guard now narrows `context` properly and validates that `logs` really is a `string[]`.

**`grill` — `createPdaQuery` dropped falsy PDA seeds.** `if (!args)` returned `null` for any falsy `args`, so a valid seed of `0` or `""` never reached `pdaFn`. `TArgs` is unconstrained, and the line directly below it (`enabled: args !== undefined`) already showed the intent was a nullish check. Now `args === null || args === undefined`.

**`dataloader-es` — an unsound generic hidden by method bivariance.** `getValidCacheKeyFn` widened its value type to `unknown` and passed `Options<K, V, C>` where `Options<K, unknown, C>` was expected. That only typechecked because `CacheMap`'s members used method shorthand, which TypeScript checks bivariantly. Switching `CacheMap` to property signatures made `tsc` reject the call immediately; the helper is now generic over the value type like its sibling `getValidCacheMap`.

Three smaller dead conditions also went: `!!mergePool` in the three `react-quarry` `isReady` flags (`mergePool` comes from a context that throws when absent, so it is always truthy), and `if (signature)` after `sendTX` in the demo (`sendTX` throws rather than returning a falsy signature).

## Rules enabled

Tightened options on rules that were already on but running with oxlint's loose defaults:

- **`restrict-template-expressions`** — oxlint defaults `allowAny`, `allowBoolean`, `allowNullish` and `allowRegExp` to `true`, so `${maybeUndefined}` and `${someAny}` passed. All now `false` (`allowNumber` stays on). 0 violations.
- **`switch-exhaustiveness-check`** — `considerDefaultExhaustiveForUnions` and `requireDefaultForNonUnion`. 0 violations.

Newly enabled type-aware rules: `strict-boolean-expressions` (see below), `strict-void-return`, `no-deprecated`, `consistent-type-exports`, `prefer-readonly`, `method-signature-style`, `require-array-sort-compare`, `no-unnecessary-qualifier`, `no-unnecessary-parameter-property-assignment`, `no-useless-default-assignment`.

Newly enabled syntax-level rules, all at 0 violations: `adjacent-overload-signatures`, `ban-ts-comment`, `ban-tslint-comment`, `class-literal-property-style`, `consistent-generic-constructors`, `consistent-indexed-object-style`, `consistent-type-assertions`, `no-confusing-non-null-assertion`, `no-duplicate-enum-values`, `no-dynamic-delete`, `no-empty-object-type`, `no-extra-non-null-assertion`, `no-extraneous-class`, `no-import-type-side-effects`, `no-invalid-void-type`, `no-misused-new`, `no-namespace`, `no-non-null-asserted-nullish-coalescing`, `no-non-null-asserted-optional-chain`, `no-require-imports`, `no-this-alias`, `no-unnecessary-type-constraint`, `no-unsafe-declaration-merging`, `no-unsafe-function-type`, `no-useless-empty-export`, `no-wrapper-object-types`, `prefer-for-of`, `prefer-function-type`, `prefer-literal-enum-member`, `prefer-namespace-keyword`, `prefer-ts-expect-error`, `triple-slash-reference`, `unified-signatures`.

`no-unused-vars` and `react/only-export-components` were escalated from `warn` to `error` (both already clean).

### `strict-boolean-expressions`, partially

Enabled with the nullable-primitive escapes on (`allowNullableString`/`Boolean`/`Number`/`Enum`), which takes it from **57 violations to 19**. `if (maybeName)`, `if (flag)` and `if (arr?.length)` are the dominant idiom here and rewriting ~38 of them to `!= null && !== ""` is churn with no behaviour change. What stays on is the part that found actual problems: `allowAny: false` (this is what caught the `extractErrorLogs` bug), always-truthy objects, and unions whose members disagree about truthiness (`string | number`, `string | object | null`). All 19 are fixed.

## Rules left off

| Rule | Violations | Why |
|---|---|---|
| `prefer-readonly-parameter-types` | 346 | Would need `readonly` on essentially every parameter, including React props and `@solana/kit`'s own non-readonly types. |
| `explicit-function-return-type` | 111 | 91 are React components in `example-dapp`, where `: JSX.Element` adds nothing. The published surface is already covered — `isolatedDeclarations` forces return types on every export in `packages/*`. |
| `explicit-module-boundary-types` | 60 | Same, and same reason. |
| `no-unsafe-type-assertion` | 57 | Every hit is a load-bearing narrowing cast the domain requires: branded types (`as Address`, `as Signature`, `as SignatureBytes`), dnum tuples (`as readonly [bigint, TDecimals]`), decoder generics (`as Account<TDecodedData>`). The only way to satisfy it is `as unknown as T`, which is strictly worse. typescript-eslint ships it in no preset for the same reason. |
| `promise-function-async` | 39 | 31 are in `dataloader-es`, where adding `async` to functions that already return a promise inserts an extra microtask. Batch scheduling there is timing sensitive. |
| `consistent-return` | 2 | Both are `useEffect` callbacks returning a cleanup on one path and bare `return;` on another — the documented React idiom. The rule would force `return undefined;`. |

Each is recorded in `.oxlintrc.json` with its count and reason, so the next person does not have to re-derive this.

## tsconfig strictness

New `tsconfig.strict.json` at the repo root, layered on top of `@macalinao/tsconfig` (which already sets `strict`, `noUncheckedIndexedAccess`, `noUnusedLocals`, `noUnusedParameters`, `noImplicitOverride`, `noFallthroughCasesInSwitch`, `isolatedDeclarations`). Every package extends it as the second entry of its `extends` array. Adds `noImplicitReturns`, `noUncheckedSideEffectImports`, `erasableSyntaxOnly`, `allowUnreachableCode: false`, `allowUnusedLabels: false` (all 0 errors) and `noPropertyAccessFromIndexSignature` (4 errors, all in `das-api` tests, fixed with bracket access).

`isolatedDeclarations` is re-enabled in **`das-api`** and **`solana-errors`**, which were opted out and turned out to already pass. **`gill-extra`** stays opted out, documented in its tsconfig: `getConfirmedTransaction` returns whatever `rpc.getTransaction(sig, { encoding: "jsonParsed", ... }).send()` returns, and `GetTransactionApi["getTransaction"]` is a four-way overload keyed on `encoding` — `ReturnType<>` resolves to the wrong one (`encoding: "json"`), and inference is the only thing that gets it right.

**`exactOptionalPropertyTypes` rejected** (46 errors: `das-api` 30, `grill` 7, `zod-solana` 5, `gill-extra` 3, `react-quarry` 1). The `das-api`/`zod-solana` half is mechanical, but the `grill` half does not survive contact with `@tanstack/react-query`'s option objects — `placeholderData: X | undefined` is not assignable to `placeholderData?: X`, so every one of them would have to be passed via a conditional spread. Noted in `tsconfig.strict.json`.

## Verification

`bun run build` (clean, no cache), `bun run lint` (exit 0, run twice — stable), `bun run test` (622 pass, 0 fail).

## Changeset

Added, patch. The lint config alone would not warrant one, but the fixes above change runtime behaviour in `grill` (the `context: null` crash and the falsy-seed skip) and several packages' public `.d.ts` shape (method shorthand to property signatures).
