### PR TITLE
feat(grill): injectable latestBlockhash for sendTX

### DIFF
--- a/.changeset/injectable-blockhash.md
+++ b/.changeset/injectable-blockhash.md
@@ -1,0 +1,6 @@
+---
+"@macalinao/grill": minor
+"@macalinao/gill-extra": minor
+---
+
+Add an optional `latestBlockhash` to the transaction send options. When provided, `sendTX` builds the transaction with the supplied blockhash instead of fetching a fresh one via `rpc.getLatestBlockhash()`, letting callers who maintain their own up-to-date blockhash skip an RPC round trip per transaction.

--- a/packages/gill-extra/src/types.ts
+++ b/packages/gill-extra/src/types.ts
@@ -7,12 +7,6 @@ import type {
 } from "@solana/kit";
 import type { CreateTransactionInput } from "gill";
 
-/**
- * A blockhash lifetime constraint (`{ blockhash, lastValidBlockHeight }`),
- * i.e. the `.value` returned by `rpc.getLatestBlockhash().send()`.
- */
-export type LatestBlockhash = BlockhashLifetimeConstraint;
-
 export interface SendTXOptions extends Pick<
   CreateTransactionInput<0>,
   "computeUnitLimit" | "computeUnitPrice"
@@ -41,7 +35,7 @@ export interface SendTXOptions extends Pick<
    * up-to-date blockhash (e.g. a background poll/cache) to avoid an RPC round
    * trip on every transaction. When omitted, the latest blockhash is fetched.
    */
-  latestBlockhash?: LatestBlockhash;
+  latestBlockhash?: BlockhashLifetimeConstraint;
 }
 
 export type SendTXFunction = (

--- a/packages/gill-extra/src/types.ts
+++ b/packages/gill-extra/src/types.ts
@@ -1,9 +1,9 @@
 import type {
   Account,
   AddressesByLookupTableAddress,
+  BlockhashLifetimeConstraint,
   Instruction,
   Signature,
-  TransactionMessageWithBlockhashLifetime,
 } from "@solana/kit";
 import type { CreateTransactionInput } from "gill";
 
@@ -11,8 +11,7 @@ import type { CreateTransactionInput } from "gill";
  * A blockhash lifetime constraint (`{ blockhash, lastValidBlockHeight }`),
  * i.e. the `.value` returned by `rpc.getLatestBlockhash().send()`.
  */
-export type LatestBlockhash =
-  TransactionMessageWithBlockhashLifetime["lifetimeConstraint"];
+export type LatestBlockhash = BlockhashLifetimeConstraint;
 
 export interface SendTXOptions extends Pick<
   CreateTransactionInput<0>,

--- a/packages/gill-extra/src/types.ts
+++ b/packages/gill-extra/src/types.ts
@@ -3,8 +3,16 @@ import type {
   AddressesByLookupTableAddress,
   Instruction,
   Signature,
+  TransactionMessageWithBlockhashLifetime,
 } from "@solana/kit";
 import type { CreateTransactionInput } from "gill";
+
+/**
+ * A blockhash lifetime constraint (`{ blockhash, lastValidBlockHeight }`),
+ * i.e. the `.value` returned by `rpc.getLatestBlockhash().send()`.
+ */
+export type LatestBlockhash =
+  TransactionMessageWithBlockhashLifetime["lifetimeConstraint"];
 
 export interface SendTXOptions extends Pick<
   CreateTransactionInput<0>,
@@ -27,6 +35,14 @@ export interface SendTXOptions extends Pick<
    * If true, skips the pre-flight simulation.
    */
   skipPreflight?: boolean;
+  /**
+   * A pre-fetched blockhash to use for the transaction. When provided, the
+   * transaction is built with this blockhash instead of fetching a fresh one
+   * via `rpc.getLatestBlockhash()`. Useful when a caller maintains its own
+   * up-to-date blockhash (e.g. a background poll/cache) to avoid an RPC round
+   * trip on every transaction. When omitted, the latest blockhash is fetched.
+   */
+  latestBlockhash?: LatestBlockhash;
 }
 
 export type SendTXFunction = (

--- a/packages/grill/package.json
+++ b/packages/grill/package.json
@@ -43,7 +43,8 @@
     "build": "tsdown",
     "dev": "tsdown --watch",
     "typecheck": "tsc --noEmit",
-    "clean": "rm -fr dist/ node_modules/ tsconfig.tsbuildinfo"
+    "clean": "rm -fr dist/ node_modules/ tsconfig.tsbuildinfo",
+    "test": "bun test src/"
   },
   "dependencies": {
     "@gillsdk/react": "catalog:",

--- a/packages/grill/src/utils/internal/create-send-tx.test.ts
+++ b/packages/grill/src/utils/internal/create-send-tx.test.ts
@@ -1,0 +1,133 @@
+import type { LatestBlockhash } from "@macalinao/gill-extra";
+import type {
+  Address,
+  Blockhash,
+  Instruction,
+  SignatureBytes,
+  TransactionSendingSigner,
+} from "@solana/kit";
+import type { SolanaClient } from "gill";
+import { beforeAll, describe, expect, it, mock } from "bun:test";
+import * as gillExtra from "@macalinao/gill-extra";
+import { address, generateKeyPairSigner, getBase58Encoder } from "@solana/kit";
+
+const BLOCKHASH: LatestBlockhash = {
+  blockhash: "11111111111111111111111111111111" as Blockhash,
+  lastValidBlockHeight: 100n,
+};
+
+const INJECTED: LatestBlockhash = {
+  blockhash: "So11111111111111111111111111111111111111112" as Blockhash,
+  lastValidBlockHeight: 200n,
+};
+
+const MEMO_PROGRAM = address("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr");
+
+// A fixed 64-byte signature returned by the sending signer.
+const SIG_BYTES = new Uint8Array(64).fill(7) as SignatureBytes;
+
+/**
+ * Captures the `lastValidBlockHeight` handed to `pollConfirmTransaction` so we
+ * can assert which blockhash was baked into the transaction. The rest of the
+ * gill-extra exports used by create-send-tx are preserved. A holder object is
+ * used so control-flow narrowing does not collapse the value to `undefined`
+ * across the awaited `sendTX` call.
+ */
+const polled: { lastValidBlockHeight?: bigint } = {};
+
+await mock.module("@macalinao/gill-extra", () => ({
+  ...gillExtra,
+  pollConfirmTransaction: ({
+    lastValidBlockHeight,
+  }: {
+    lastValidBlockHeight: bigint;
+  }) => {
+    polled.lastValidBlockHeight = lastValidBlockHeight;
+    return Promise.resolve({
+      transaction: { message: { accountKeys: [] } },
+      meta: { logMessages: [] },
+    });
+  },
+}));
+
+// Imported after the module mock is installed so the mocked binding is used.
+const { createSendTX } = await import("./create-send-tx.js");
+
+function makeIx(signerAddress: Address): Instruction {
+  return {
+    programAddress: MEMO_PROGRAM,
+    accounts: [],
+    data: getBase58Encoder().encode(signerAddress),
+  };
+}
+
+function makeRpc(): {
+  rpc: SolanaClient["rpc"];
+  getLatestBlockhashCalls: () => number;
+} {
+  let calls = 0;
+  const rpc = {
+    getLatestBlockhash: () => ({
+      send: () => {
+        calls += 1;
+        return Promise.resolve({ value: BLOCKHASH });
+      },
+    }),
+  } as unknown as SolanaClient["rpc"];
+  return { rpc, getLatestBlockhashCalls: () => calls };
+}
+
+function makeSendingSigner(addr: Address): TransactionSendingSigner {
+  return {
+    address: addr,
+    signAndSendTransactions: () => Promise.resolve([SIG_BYTES]),
+  };
+}
+
+describe("createSendTX blockhash injection", () => {
+  let signer: TransactionSendingSigner;
+
+  beforeAll(async () => {
+    const kp = await generateKeyPairSigner();
+    signer = makeSendingSigner(kp.address);
+  });
+
+  const params = (rpc: SolanaClient["rpc"]) => ({
+    signer,
+    rpc,
+    refetchAccounts: () => Promise.resolve(),
+    onTransactionStatusEvent: () => {},
+    getExplorerLink: () => "https://example.com",
+  });
+
+  it("uses an injected blockhash without hitting the RPC", async () => {
+    polled.lastValidBlockHeight = undefined;
+    const { rpc, getLatestBlockhashCalls } = makeRpc();
+    const sendTX = createSendTX(params(rpc));
+
+    await sendTX("Test", [makeIx(signer.address)], {
+      skipPreflight: true,
+      latestBlockhash: INJECTED,
+    });
+
+    expect(getLatestBlockhashCalls()).toBe(0);
+    expect<bigint | undefined>(polled.lastValidBlockHeight).toBe(
+      INJECTED.lastValidBlockHeight,
+    );
+  });
+
+  it("fetches the blockhash when not injected", async () => {
+    polled.lastValidBlockHeight = undefined;
+    const { rpc, getLatestBlockhashCalls } = makeRpc();
+    const sendTX = createSendTX(params(rpc));
+
+    await sendTX("Test", [makeIx(signer.address)], {
+      skipPreflight: true,
+    });
+
+    expect(getLatestBlockhashCalls()).toBe(1);
+    expect<bigint | undefined>(polled.lastValidBlockHeight).toBe(
+      BLOCKHASH.lastValidBlockHeight,
+    );
+  });
+});

--- a/packages/grill/src/utils/internal/create-send-tx.test.ts
+++ b/packages/grill/src/utils/internal/create-send-tx.test.ts
@@ -1,7 +1,7 @@
-import type { LatestBlockhash } from "@macalinao/gill-extra";
 import type {
   Address,
   Blockhash,
+  BlockhashLifetimeConstraint,
   Instruction,
   SignatureBytes,
   TransactionSendingSigner,
@@ -11,12 +11,12 @@ import { beforeAll, describe, expect, it, mock } from "bun:test";
 import * as gillExtra from "@macalinao/gill-extra";
 import { address, generateKeyPairSigner, getBase58Encoder } from "@solana/kit";
 
-const BLOCKHASH: LatestBlockhash = {
+const BLOCKHASH: BlockhashLifetimeConstraint = {
   blockhash: "11111111111111111111111111111111" as Blockhash,
   lastValidBlockHeight: 100n,
 };
 
-const INJECTED: LatestBlockhash = {
+const INJECTED: BlockhashLifetimeConstraint = {
   blockhash: "So11111111111111111111111111111111111111112" as Blockhash,
   lastValidBlockHeight: 200n,
 };

--- a/packages/grill/src/utils/internal/create-send-tx.ts
+++ b/packages/grill/src/utils/internal/create-send-tx.ts
@@ -84,7 +84,8 @@ export const createSendTX = ({
       type: "preparing",
     });
 
-    const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+    const latestBlockhash =
+      options.latestBlockhash ?? (await rpc.getLatestBlockhash().send()).value;
     const transactionMessage = createTransaction({
       version: 0,
       feePayer: signer,


### PR DESCRIPTION
## What

Adds an optional `latestBlockhash` field to the transaction send options (`SendTXOptions`). When provided, `sendTX` builds the transaction with the supplied blockhash instead of fetching a fresh one via `rpc.getLatestBlockhash()`.

- `@macalinao/gill-extra`: new exported `LatestBlockhash` type (the `.value` of `rpc.getLatestBlockhash().send()`) and a `latestBlockhash?` field on `SendTXOptions`.
- `@macalinao/grill`: `createSendTX` uses `options.latestBlockhash ?? (await rpc.getLatestBlockhash().send()).value`. Everything downstream (simulation, poll/confirm using `lastValidBlockHeight`) is unchanged.
- Adds `create-send-tx.test.ts` proving that an injected blockhash skips the RPC call and is the one baked into the transaction, and that the blockhash is fetched when omitted. Adds the missing `test` script to `packages/grill`.

## Why

Callers that maintain their own up-to-date blockhash (e.g. a background poll/cache) can skip a `getLatestBlockhash` RPC round trip on every transaction.

## Notes

Split out of a combined feature branch (`macalinao/transaction-signer`) that mixed two features. This PR is only the injectable-blockhash half. A sibling PR adds sign-without-send (`useSignTX`). Some file overlap between the two PRs is expected.

Includes a changeset (`minor` for `@macalinao/grill` and `@macalinao/gill-extra`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Allow transactions sent via grill to optionally use a caller-supplied latest blockhash instead of always fetching a fresh one, and add tests and metadata for this behavior.

New Features:
- Introduce a LatestBlockhash type in gill-extra and expose an optional latestBlockhash field on SendTXOptions to let callers inject a pre-fetched blockhash for transaction sending.

Enhancements:
- Update createSendTX to respect an injected latestBlockhash when present while preserving existing simulation and confirmation behavior.

Tests:
- Add unit tests for createSendTX to verify injected blockhash usage versus RPC blockhash fetching and wire up a test script for the grill package.

Chores:
- Add a changeset marking minor version bumps for @macalinao/grill and @macalinao/gill-extra in support of the new latestBlockhash option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional `latestBlockhash` setting for transaction sending.
  - When supplied, transactions use the provided blockhash and validity data for confirmation instead of fetching the latest blockhash again.
  - Helps reduce per-transaction network overhead when callers already have blockhash details.

- **Tests**
  - Added Bun coverage ensuring injected `latestBlockhash` is respected (no extra latest-blockhash RPC call) and that the prior auto-fetch behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->