### PR TITLE
chore(oxlint): enable experimental typeCheck option

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,7 +1,8 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
   "options": {
-    "typeAware": true
+    "typeAware": true,
+    "typeCheck": true
   },
   "plugins": ["typescript", "unicorn", "oxc", "import", "promise", "react"],
   // Only `correctness` is denied by category. The categories oxlint layers on


### PR DESCRIPTION
## Summary

Adds `"typeCheck": true` alongside the existing `"typeAware": true` in the `options` object of `.oxlintrc.json`. These are two distinct oxlint options:

- `typeAware` — enables type-info lint rules (via tsgolint).
- `typeCheck` — enables oxlint's experimental type checking (the `--type-check` flag), which surfaces TypeScript compiler diagnostics as part of the lint run.

```json
"options": {
  "typeAware": true,
  "typeCheck": true
},
```

## Lint outcome

Ran `bun run lint` in the worktree (oxlint v1.73.0). It passed clean — exit 0, oxlint finished on 331 files with no errors or warnings; ast-grep, oxfmt `--check`, and `turbo run typecheck` all passed as well.

Caveat for reviewers: `typeCheck` is experimental. It did not surface new diagnostics in this run, but because it enables TS-compiler-backed checking it may produce additional diagnostics as the codebase evolves and could make lint fail in future runs.

## Summary by Sourcery

Build:
- Add oxlint `typeCheck` option alongside existing `typeAware` setting in .oxlintrc.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled TypeScript type-checking during linting to improve code quality validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->