### PR TITLE
feat: guard decode errors and make React Query the source of truth for accounts

### DIFF
--- a/.changeset/guard-decode-errors.md
+++ b/.changeset/guard-decode-errors.md
@@ -1,0 +1,36 @@
+---
+"@macalinao/solana-batch-accounts-loader": minor
+"@macalinao/gill-extra": minor
+"@macalinao/grill": minor
+---
+
+Guard account decode errors, and make React Query the single source of truth for account data.
+
+### Account data is no longer memoized forever
+
+`createBatchAccountsLoader` previously used DataLoader's default `cache: true`, giving it a permanent, unbounded per-address cache for the lifetime of the provider. Because every read goes through the loader, this silently shadowed React Query: `invalidateQueries`, `refetch()`, `staleTime`, `refetchOnMount` and `refetchOnWindowFocus` would all re-run the query function only to replay the same cached bytes. Account data was effectively frozen until `refetchAccounts` was called explicitly.
+
+The loader now defaults to `cache: false`, making it a **pure request coalescer**: concurrent loads are still batched into a single `getMultipleAccounts` call (still chunked at 99), but nothing is retained afterwards. Duplicate addresses within a batch are deduped so they don't consume slots. React Query is now the only cache, so standard invalidation actually refetches from the RPC.
+
+- Pass `cache: true` to `createBatchAccountsLoader` to restore the old memoizing behavior (only advisable for short-lived loaders).
+- **Note:** accounts now respect `staleTime` (React Query's default is `0`). Set a `staleTime` on your `QueryClient` to trade freshness for fewer RPC calls.
+- Fixes a latent bug where a failed chunk returned a single `Error` for the whole chunk, misaligning the results array with the requested keys (DataLoader requires one result per key).
+
+### Forcing a refresh no longer requires a hook
+
+`createAccountQueryKey(address)` is a plain function, so you can now refresh an account from anywhere you have a `QueryClient` — a mutation callback, an event handler, a service module — with no React context:
+
+```ts
+await queryClient.invalidateQueries({
+  queryKey: createAccountQueryKey(address),
+  exact: true,
+});
+```
+
+New `useRefetchAccount()` / `useRefetchAccounts()` hooks are available as convenience sugar for use inside components. Both refresh only the addresses passed. Documented in the README.
+
+### Decode errors are guarded
+
+- New `AccountDecodeError` (from `@macalinao/gill-extra`, re-exported by `@macalinao/grill`). When a decoder throws, the raw failure is wrapped with the account's `address` and `programAddress` (owner) so it can be traced to a specific on-chain account instead of an opaque "index out of bounds"-style message. The original error is kept as `.cause`.
+- `useAccount`/`useAccounts` decode failures now surface as an `AccountDecodeError` on the query's `error` instead of an unlabeled throw.
+- Subscription decodes are now guarded per-notification: a malformed `accountNotifications` update is logged (with address/owner context) and skipped, keeping the last good value in the cache and leaving the subscription running, rather than tearing it down.

--- a/apps/example-dapp/src/routes/examples/account-hooks.tsx
+++ b/apps/example-dapp/src/routes/examples/account-hooks.tsx
@@ -13,6 +13,8 @@ import {
   useAddressLookupTables,
   useMintAccount,
   useMintAccounts,
+  useRefetchAccount,
+  useRefetchAccounts,
   useTokenAccount,
   useTokenAccounts,
 } from "@macalinao/grill";
@@ -21,6 +23,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { useState } from "react";
 import { CodeBlock } from "@/components/examples/code-block";
 import { ExampleHeader } from "@/components/examples/example-header";
+import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -317,6 +320,69 @@ const LookupTableCard: React.FC = () => {
   );
 };
 
+/** `useRefetchAccount` (singular) and `useRefetchAccounts` (plural). */
+const RefetchCard: React.FC = () => {
+  const refetchAccount = useRefetchAccount();
+  const refetchAccounts = useRefetchAccounts();
+
+  const [refreshedAt, setRefreshedAt] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const usdcMint = DEMO_TOKENS[0]?.mint;
+
+  const run = async (refetch: () => Promise<void>): Promise<void> => {
+    setBusy(true);
+    try {
+      await refetch();
+      setRefreshedAt(new Date().toLocaleTimeString());
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Refreshing accounts</CardTitle>
+        <CardDescription>
+          <code className="font-mono">useRefetchAccount</code> re-reads one
+          address from the RPC;{" "}
+          <code className="font-mono">useRefetchAccounts</code> takes several
+          and coalesces them into a single batched call. The mint cards above
+          update in place.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="flex flex-wrap gap-2">
+          <Button
+            variant="outline"
+            disabled={busy || !usdcMint}
+            onClick={() => {
+              if (usdcMint) {
+                void run(() => refetchAccount(usdcMint));
+              }
+            }}
+          >
+            Refetch USDC mint
+          </Button>
+          <Button
+            variant="outline"
+            disabled={busy}
+            onClick={() => void run(() => refetchAccounts(DEMO_MINTS))}
+          >
+            Refetch all {DEMO_MINTS.length} mints
+          </Button>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          {refreshedAt === null
+            ? "Not refetched yet."
+            : `Last refetched at ${refreshedAt}.`}
+        </p>
+      </CardContent>
+    </Card>
+  );
+};
+
 function AccountHooksPage() {
   return (
     <div className="container mx-auto py-6">
@@ -329,6 +395,8 @@ function AccountHooksPage() {
           "useTokenAccounts",
           "useAddressLookupTable",
           "useAddressLookupTables",
+          "useRefetchAccount",
+          "useRefetchAccounts",
         ]}
       >
         Grill ships typed hooks for the account types every Solana app touches.
@@ -343,6 +411,8 @@ function AccountHooksPage() {
         </div>
 
         <LookupTableCard />
+
+        <RefetchCard />
 
         <Card>
           <CardHeader>

--- a/packages/gill-extra/src/account-decode-error.test.ts
+++ b/packages/gill-extra/src/account-decode-error.test.ts
@@ -1,0 +1,37 @@
+import type { Address } from "gill";
+import { describe, expect, it } from "bun:test";
+import { AccountDecodeError } from "./account-decode-error.js";
+
+const ADDRESS = "So11111111111111111111111111111111111111112" as Address;
+const OWNER = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA" as Address;
+
+describe("AccountDecodeError", () => {
+  it("includes the address, owner, and data length in the message", () => {
+    const err = new AccountDecodeError({
+      address: ADDRESS,
+      programAddress: OWNER,
+      data: new Uint8Array(165),
+    });
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("AccountDecodeError");
+    expect(err.message).toBe(
+      `Failed to decode account ${ADDRESS} (owner ${OWNER}, 165 bytes)`,
+    );
+    expect(err.address).toBe(ADDRESS);
+    expect(err.programAddress).toBe(OWNER);
+    expect(err.dataLength).toBe(165);
+  });
+
+  it("degrades gracefully when only the address is known", () => {
+    const err = new AccountDecodeError({ address: ADDRESS });
+    expect(err.message).toBe(`Failed to decode account ${ADDRESS}`);
+    expect(err.programAddress).toBeUndefined();
+    expect(err.dataLength).toBeUndefined();
+  });
+
+  it("preserves the original error as `cause`", () => {
+    const cause = new Error("index out of bounds");
+    const err = new AccountDecodeError({ address: ADDRESS }, { cause });
+    expect(err.cause).toBe(cause);
+  });
+});

--- a/packages/gill-extra/src/account-decode-error.ts
+++ b/packages/gill-extra/src/account-decode-error.ts
@@ -1,0 +1,51 @@
+import type { Address, EncodedAccount } from "gill";
+
+/**
+ * The subset of an {@link EncodedAccount} needed to describe a decode failure.
+ *
+ * Both the fetch path (which has a full `EncodedAccount`) and the subscription
+ * path (which parses one from a notification) can construct this.
+ */
+export type DecodableAccount = Pick<EncodedAccount, "address"> &
+  Partial<Pick<EncodedAccount, "programAddress" | "data">>;
+
+/**
+ * Thrown when an account's raw `data` bytes cannot be decoded with the provided
+ * decoder.
+ *
+ * Decoders throw for a variety of reasons — the account's on-chain layout does
+ * not match the decoder (e.g. a stale or wrong-program account at the expected
+ * address), the discriminator is unexpected, or the data is truncated. Wrapping
+ * those raw failures in this error attaches the account `address` and `owner`
+ * (program) so the failure can be traced to a specific on-chain account instead
+ * of surfacing as an opaque "index out of bounds"-style message.
+ *
+ * The original error is available via the standard {@link Error.cause} property.
+ */
+export class AccountDecodeError extends Error {
+  /** Address of the account that failed to decode. */
+  readonly address: Address;
+  /** Owner (program) of the account, when known. */
+  readonly programAddress: Address | undefined;
+  /** Length in bytes of the account `data` that failed to decode, when known. */
+  readonly dataLength: number | undefined;
+
+  constructor(account: DecodableAccount, options?: { cause?: unknown }) {
+    const { address, programAddress, data } = account;
+    const dataLength = data?.length;
+    const details = [
+      programAddress ? `owner ${programAddress}` : undefined,
+      dataLength === undefined ? undefined : `${dataLength.toString()} bytes`,
+    ].filter(Boolean);
+    super(
+      `Failed to decode account ${address}${
+        details.length > 0 ? ` (${details.join(", ")})` : ""
+      }`,
+      options,
+    );
+    this.name = "AccountDecodeError";
+    this.address = address;
+    this.programAddress = programAddress;
+    this.dataLength = dataLength;
+  }
+}

--- a/packages/gill-extra/src/fetch-and-decode-account.ts
+++ b/packages/gill-extra/src/fetch-and-decode-account.ts
@@ -1,6 +1,7 @@
 import type { DataLoader } from "@macalinao/dataloader-es";
 import type { Account, Address, Decoder, EncodedAccount } from "gill";
 import { decodeAccount } from "gill";
+import { AccountDecodeError } from "./account-decode-error.js";
 
 /**
  * Fetch and decode an account using the DataLoader
@@ -24,7 +25,13 @@ export async function fetchAndDecodeAccount<
     return null;
   }
   if (decoder) {
-    return decodeAccount(account, decoder);
+    try {
+      return decodeAccount(account, decoder);
+    } catch (cause) {
+      // Wrap the raw decoder failure with the account's address/owner so the
+      // React Query error state points at a specific on-chain account.
+      throw new AccountDecodeError(account, { cause });
+    }
   }
   return account as Account<TDecodedData>;
 }

--- a/packages/gill-extra/src/index.ts
+++ b/packages/gill-extra/src/index.ts
@@ -3,6 +3,7 @@ export * from "@macalinao/token-utils";
 export * from "@macalinao/zod-solana";
 export { createSolanaClient, getExplorerLink } from "gill";
 // Export gill-extra specific utilities
+export * from "./account-decode-error.js";
 export * from "./build-get-explorer-link-function.js";
 export * from "./constants.js";
 export * from "./fetch-and-decode-account.js";

--- a/packages/grill/README.md
+++ b/packages/grill/README.md
@@ -166,6 +166,102 @@ Access the wallet signer and connection:
 const { signer, publicKey } = useKitWallet();
 ```
 
+### useRefetchAccount / useRefetchAccounts
+
+Convenience hooks to force-refresh accounts (e.g. balances) from inside a
+component:
+
+```tsx
+const refetchAccount = useRefetchAccount();
+await refetchAccount(tokenAccountAddress);
+```
+
+You don't have to use a hook — see [Refreshing Account Data](#refreshing-account-data)
+for the query-key approach, which works anywhere you have a `QueryClient`.
+
+## Refreshing Account Data
+
+**React Query is the single source of truth for account data.** Grill's
+DataLoader only coalesces concurrent requests inside its batch window (so N
+components asking for N accounts still make one RPC call) — it retains nothing
+afterwards. That means standard React Query invalidation just works.
+
+The canonical way to force a refresh is the query key. `createAccountQueryKey`
+is a plain function, not a hook, so you can use it anywhere you have a
+`QueryClient` — a mutation callback, an event handler, a plain service module —
+with no React context involved:
+
+```ts
+import { createAccountQueryKey } from "@macalinao/grill";
+
+// Refresh one account (e.g. a token balance) after a transaction
+await queryClient.invalidateQueries({
+  queryKey: createAccountQueryKey(address),
+  exact: true,
+});
+```
+
+Because the namespace is shared, you can also invalidate broadly:
+
+```ts
+import { GRILL_REACT_QUERY_NAMESPACE } from "@macalinao/grill";
+
+// Refresh every account grill knows about
+await queryClient.invalidateQueries({
+  queryKey: [GRILL_REACT_QUERY_NAMESPACE, "account"],
+});
+```
+
+Everything else follows from React Query too: `refetch()` from `useAccount`,
+`staleTime`, `refetchOnWindowFocus`, and `refetchOnMount` all behave normally
+and will actually hit the RPC.
+
+> 💡 Since accounts are no longer memoized forever, `staleTime` (React Query's
+> default is `0`) now governs how often they refetch. Set a `staleTime` on your
+> `QueryClient` if you want to trade freshness for fewer RPC calls.
+
+### Optional hooks
+
+If you're already inside a component, `useRefetchAccount` / `useRefetchAccounts`
+are thin sugar over the same thing (they also clear the DataLoader, which
+matters only if you opted into `cache: true`):
+
+```tsx
+const refetchAccount = useRefetchAccount();
+await refetchAccount(tokenAccountAddress);
+
+const refetchAccounts = useRefetchAccounts();
+await refetchAccounts([addressA, addressB]); // batched into one RPC call
+```
+
+Both only refresh the addresses you pass — they don't refresh the whole cache.
+
+Note that transactions sent via `useSendTX` **already refetch every writable
+account** automatically once confirmed, so you often don't need to refresh
+manually at all.
+
+To refresh a **token balance** (`useTokenBalance`), target the **token account
+address** — the balance is derived from that account plus its mint's token info.
+
+## Handling Decode Errors
+
+`useAccount`/`useAccounts` decode failures surface as the query's `error` (an
+`AccountDecodeError` carrying the offending `address` and `programAddress`), so
+one malformed account never crashes the tree:
+
+```tsx
+import { AccountDecodeError } from "@macalinao/grill";
+
+const { data, error } = useAccount({ address, decoder });
+if (error instanceof AccountDecodeError) {
+  console.warn(`Could not decode ${error.address} (owner ${error.programAddress})`);
+}
+```
+
+For live subscriptions (`subscribeToUpdates: true`), a notification that fails
+to decode is logged and skipped — the last successfully decoded value stays in
+the cache and the subscription keeps running.
+
 ## Transaction Status Events
 
 The provider emits the following transaction status events:

--- a/packages/grill/src/contexts/subscription-context.ts
+++ b/packages/grill/src/contexts/subscription-context.ts
@@ -7,6 +7,7 @@ import type {
 } from "@solana/kit";
 import type { QueryClient } from "@tanstack/react-query";
 import type { RpcSubscriptions, SolanaRpcSubscriptionsApi } from "gill";
+import { AccountDecodeError } from "@macalinao/gill-extra";
 import { getBase64Encoder } from "@solana/kit";
 import { createContext, useContext } from "react";
 import { createAccountQueryKey } from "../query-keys.js";
@@ -45,11 +46,17 @@ export function createAccountDecoderFromDecoder<
   }
 
   return (encodedAccount: EncodedAccount): Account<TDecodedData> => {
-    const decoded = decoder.decode(encodedAccount.data);
-    return {
-      ...encodedAccount,
-      data: decoded,
-    };
+    try {
+      const decoded = decoder.decode(encodedAccount.data);
+      return {
+        ...encodedAccount,
+        data: decoded,
+      };
+    } catch (cause) {
+      // Attach the account address/owner so callers (e.g. the subscription
+      // manager) can log or surface a traceable decode failure.
+      throw new AccountDecodeError(encodedAccount, { cause });
+    }
   };
 }
 
@@ -155,14 +162,32 @@ export function createSubscriptionManager(
             continue;
           }
 
-          // Parse and decode, then update cache
+          // Parse the notification into an EncodedAccount.
           const encodedAccount = parseAccountNotification(address, value);
-          const decoded = decoder(encodedAccount);
+
+          // Guard the decode itself: a single malformed notification must not
+          // tear down the subscription or clobber the last good cached value.
+          let decoded: Account<T>;
+          try {
+            decoded = decoder(encodedAccount);
+          } catch (decodeError) {
+            console.error(
+              `[SubscriptionManager] ${
+                decodeError instanceof AccountDecodeError
+                  ? decodeError.message
+                  : `Failed to decode account ${address}`
+              }; keeping last cached value`,
+              decodeError,
+            );
+            continue;
+          }
+
+          // Only update the cache once we have a successfully decoded value.
           queryClient.setQueryData(createAccountQueryKey(address), decoded);
-        } catch (decodeError) {
+        } catch (error) {
           console.error(
-            `[SubscriptionManager] Error decoding account ${address}:`,
-            decodeError,
+            `[SubscriptionManager] Error handling notification for ${address}:`,
+            error,
           );
         }
       }

--- a/packages/grill/src/hooks/index.ts
+++ b/packages/grill/src/hooks/index.ts
@@ -10,6 +10,7 @@ export * from "./use-associated-token-account.js";
 export * from "./use-ata-balance.js";
 export { useConnectedWallet } from "./use-connected-wallet.js";
 export { useKitWallet } from "./use-kit-wallet.js";
+export * from "./use-refetch-accounts.js";
 export * from "./use-send-tx.js";
 export * from "./use-token-balance.js";
 export * from "./use-token-info.js";

--- a/packages/grill/src/hooks/use-refetch-accounts.ts
+++ b/packages/grill/src/hooks/use-refetch-accounts.ts
@@ -1,0 +1,81 @@
+import type { Address } from "@solana/kit";
+import { useCallback } from "react";
+import { useGrillContext } from "../contexts/grill-context.js";
+
+/**
+ * Returns a function that force-refreshes the given accounts.
+ *
+ * This is convenience sugar for use inside components. You do not need a hook
+ * to refresh an account: React Query is the single source of truth for account
+ * data, so `createAccountQueryKey(address)` + `queryClient.invalidateQueries`
+ * works from anywhere you have a `QueryClient` — no React context required.
+ * Reach for this hook when you're already in a component and want the batching
+ * to be handled for you.
+ *
+ * Passing several addresses lets their reads coalesce into a single batched RPC
+ * call. Only the addresses you pass are refreshed — this never clears the whole
+ * cache.
+ *
+ * Note that transactions sent via {@link useSendTX} already refetch every
+ * writable account automatically, so you often don't need this at all.
+ *
+ * To refresh a **token balance** (from `useTokenBalance`), pass the token
+ * account address — the balance is derived from that account plus its mint's
+ * token info.
+ *
+ * @example
+ * ```tsx
+ * const refetchAccounts = useRefetchAccounts();
+ *
+ * async function onDeposit() {
+ *   await sendTX(...);
+ *   // Refresh balances that aren't writable accounts of the tx:
+ *   await refetchAccounts([tokenAccountA, tokenAccountB]);
+ * }
+ * ```
+ *
+ * @returns A function that refetches the given addresses.
+ */
+export const useRefetchAccounts = (): ((
+  addresses: Address[],
+) => Promise<void>) => {
+  const { refetchAccounts } = useGrillContext();
+  return refetchAccounts;
+};
+
+/**
+ * Returns a function that force-refreshes a single account.
+ *
+ * The singular counterpart to {@link useRefetchAccounts} for the common
+ * one-account case — refreshing a balance after a transaction, a manual refresh
+ * button, etc.
+ *
+ * As with the plural hook, this is only sugar: outside a component, use
+ * `createAccountQueryKey(address)` with `queryClient.invalidateQueries`.
+ *
+ * To refresh a **token balance** (from `useTokenBalance`), pass the token
+ * account address — the balance is derived from that account plus its mint's
+ * token info.
+ *
+ * When refreshing several accounts at once, prefer {@link useRefetchAccounts}
+ * so the reads coalesce into a single batched RPC call.
+ *
+ * @example
+ * ```tsx
+ * const refetchAccount = useRefetchAccount();
+ *
+ * async function onDeposit() {
+ *   await sendTX(...);
+ *   await refetchAccount(tokenAccountAddress);
+ * }
+ * ```
+ *
+ * @returns A function that clears the cache for the given address and refetches it.
+ */
+export const useRefetchAccount = (): ((address: Address) => Promise<void>) => {
+  const { refetchAccounts } = useGrillContext();
+  return useCallback(
+    (address: Address) => refetchAccounts([address]),
+    [refetchAccounts],
+  );
+};

--- a/packages/grill/src/query-keys.ts
+++ b/packages/grill/src/query-keys.ts
@@ -17,7 +17,25 @@ export type PdaQueryKey<TArgs> = readonly [
 ];
 
 /**
- * Create a query key for the account query
+ * Create a query key for the account query.
+ *
+ * This is the canonical way to target an account in the React Query cache. It's
+ * a plain function, not a hook, so you can force a refresh from anywhere you
+ * have a `QueryClient` — a mutation callback, an event handler, a service
+ * module — with no React context involved:
+ *
+ * ```ts
+ * await queryClient.invalidateQueries({
+ *   queryKey: createAccountQueryKey(address),
+ *   exact: true,
+ * });
+ * ```
+ *
+ * React Query is the single source of truth for account data: grill's
+ * DataLoader only coalesces concurrent requests within its batch window and
+ * retains nothing afterwards, so an invalidated query really does refetch from
+ * the RPC.
+ *
  * @param address - The address of the account
  * @returns The query key
  */

--- a/packages/solana-batch-accounts-loader/src/createBatchAccountsLoader.test.ts
+++ b/packages/solana-batch-accounts-loader/src/createBatchAccountsLoader.test.ts
@@ -87,7 +87,7 @@ describe("createBatchAccountsLoader", () => {
     expect(account3).toBeNull();
   });
 
-  it("should cache results", async () => {
+  it("does not memoize across separate loads by default", async () => {
     const sendMock = mock(() =>
       Promise.resolve({
         value: [
@@ -115,15 +115,99 @@ describe("createBatchAccountsLoader", () => {
 
     const accountId = address("11111111111111111111111111111111");
 
-    // First load
-    const result1 = await loader.load(accountId);
+    // Two sequential (non-concurrent) loads. With caching off, the loader is a
+    // pure coalescer: nothing is retained between batches, so the second load
+    // hits the RPC again and observes fresh on-chain state.
+    await loader.load(accountId);
+    await loader.load(accountId);
 
-    // Second load (should use cache)
+    expect(getMultipleAccountsMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("still coalesces concurrent loads of the same address into one RPC slot", async () => {
+    const sendMock = mock(() =>
+      Promise.resolve({
+        value: [
+          {
+            data: ["cached", "base64"],
+            executable: false,
+            lamports: 1000000n,
+            owner: "11111111111111111111111111111111",
+          },
+        ],
+      }),
+    );
+
+    const getMultipleAccountsMock = mock(() => ({
+      send: sendMock,
+    }));
+
+    const mockRpc = {
+      getMultipleAccounts: getMultipleAccountsMock,
+    };
+
+    const loader = createBatchAccountsLoader({
+      rpc: mockRpc as unknown as Rpc<GetMultipleAccountsApi>,
+    });
+
+    const accountId = address("11111111111111111111111111111111");
+
+    // Three concurrent loads of the SAME address within one batch window.
+    const [result1, result2, result3] = await Promise.all([
+      loader.load(accountId),
+      loader.load(accountId),
+      loader.load(accountId),
+    ]);
+
+    // Batching is unaffected by disabling the cache: one RPC call...
+    expect(getMultipleAccountsMock).toHaveBeenCalledTimes(1);
+    // ...and the duplicate keys are deduped, so the address is only requested
+    // once rather than consuming three slots of the 99-account limit.
+    expect(getMultipleAccountsMock).toHaveBeenCalledWith(
+      [accountId],
+      expect.anything(),
+    );
+    // Every caller still gets the value.
+    expect(result1).not.toBeNull();
+    expect(result2).toEqual(result1);
+    expect(result3).toEqual(result1);
+  });
+
+  it("memoizes for the loader's lifetime when cache is enabled", async () => {
+    const sendMock = mock(() =>
+      Promise.resolve({
+        value: [
+          {
+            data: ["cached", "base64"],
+            executable: false,
+            lamports: 1000000n,
+            owner: "11111111111111111111111111111111",
+          },
+        ],
+      }),
+    );
+
+    const getMultipleAccountsMock = mock(() => ({
+      send: sendMock,
+    }));
+
+    const mockRpc = {
+      getMultipleAccounts: getMultipleAccountsMock,
+    };
+
+    const loader = createBatchAccountsLoader({
+      rpc: mockRpc as unknown as Rpc<GetMultipleAccountsApi>,
+      cache: true,
+    });
+
+    const accountId = address("11111111111111111111111111111111");
+
+    const result1 = await loader.load(accountId);
     const result2 = await loader.load(accountId);
 
-    // Should only call RPC once
+    // Opt-in memoization: only one RPC call, same reference replayed.
     expect(getMultipleAccountsMock).toHaveBeenCalledTimes(1);
-    expect(result1).toBe(result2); // Same reference
+    expect(result1).toBe(result2);
   });
 
   it("should respect maxBatchSize", async () => {

--- a/packages/solana-batch-accounts-loader/src/createBatchAccountsLoader.ts
+++ b/packages/solana-batch-accounts-loader/src/createBatchAccountsLoader.ts
@@ -19,59 +19,82 @@ export function createBatchAccountsLoader({
   commitment = "confirmed",
   maxBatchSize = 99,
   batchDurationMs = 10,
+  cache = false,
   onFetchAccounts,
 }: BatchAccountsLoaderConfig): BatchAccountsLoader {
   return new DataLoader<Address, EncodedAccount | null>(
     async (keys) => {
+      // Caching is off by default, which makes this loader a pure request
+      // coalescer — so the same address can legitimately appear more than once
+      // in a batch. Dedupe before hitting the RPC so duplicates don't burn
+      // slots against the 99-account limit, then fan results back out to every
+      // original key below.
+      const uniqueKeys = [...new Set(keys)];
+
       // Process in chunks to respect RPC limits
       const chunks = chunk(
-        keys,
+        uniqueKeys,
         // maximum number of accounts that can be fetched in a single RPC call from a Solana RPC node
         99,
       );
 
-      return (
+      const entries = (
         await Promise.all(
-          chunks.map(async (addressChunk) => {
-            try {
-              const addresses = addressChunk.map((key) => address(key));
-              const accounts = await fetchEncodedAccounts(rpc, addresses, {
-                commitment,
-              });
+          chunks.map(
+            async (
+              addressChunk,
+            ): Promise<[Address, RawAccount | null | Error][]> => {
+              try {
+                const addresses = addressChunk.map((key) => address(key));
+                const accounts = await fetchEncodedAccounts(rpc, addresses, {
+                  commitment,
+                });
 
-              // Call onFetchAccounts callback if provided
-              if (onFetchAccounts) {
-                onFetchAccounts(addressChunk);
-              }
-
-              return accounts.map((account): RawAccount | null => {
-                if (!account.exists) {
-                  return null;
+                // Call onFetchAccounts callback if provided
+                if (onFetchAccounts) {
+                  onFetchAccounts(addressChunk);
                 }
-                return {
-                  address: account.address,
-                  data: account.data,
-                  executable: account.executable,
-                  lamports: account.lamports,
-                  programAddress: account.programAddress,
-                  space: account.space,
-                };
-              });
-            } catch (error) {
-              // If batch fails, throw error for all keys in this chunk
-              return new Error(
-                `Failed to fetch accounts: ${error instanceof Error ? error.message : String(error)}`,
-              );
-            }
-          }),
+
+                return addressChunk.map((key, i) => {
+                  const account = accounts[i];
+                  if (!account?.exists) {
+                    return [key, null];
+                  }
+                  return [
+                    key,
+                    {
+                      address: account.address,
+                      data: account.data,
+                      executable: account.executable,
+                      lamports: account.lamports,
+                      programAddress: account.programAddress,
+                      space: account.space,
+                    },
+                  ];
+                });
+              } catch (error) {
+                // If the batch fails, fail every key in this chunk. DataLoader
+                // requires exactly one result per key, so we must return an
+                // Error per key rather than a single Error for the whole chunk.
+                const chunkError = new Error(
+                  `Failed to fetch accounts: ${error instanceof Error ? error.message : String(error)}`,
+                );
+                return addressChunk.map((key) => [key, chunkError]);
+              }
+            },
+          ),
         )
       ).flat();
+
+      const resultsByAddress = new Map(entries);
+      return keys.map((key) => resultsByAddress.get(key) ?? null);
     },
     {
       batchScheduleFn: (callback) => {
         setTimeout(callback, batchDurationMs);
       },
       maxBatchSize,
+      cache,
     },
   );
 }

--- a/packages/solana-batch-accounts-loader/src/types.ts
+++ b/packages/solana-batch-accounts-loader/src/types.ts
@@ -24,6 +24,21 @@ export interface BatchAccountsLoaderConfig {
    */
   batchDurationMs?: number;
   /**
+   * Whether the loader should memoize results per address for its lifetime.
+   *
+   * Defaults to `false`, which makes the loader a pure request coalescer:
+   * concurrent loads are still batched into a single RPC call, but nothing is
+   * retained afterwards. This leaves the caching layer (e.g. React Query) as
+   * the single source of truth, so invalidating a query actually refetches from
+   * the RPC.
+   *
+   * Setting this to `true` restores DataLoader's default memoization, in which
+   * an address is fetched at most once for the lifetime of the loader and
+   * subsequent loads replay the cached value until `clear()` is called. Only do
+   * this if the loader is short-lived (e.g. scoped to a single request).
+   */
+  cache?: boolean;
+  /**
    * Called when accounts are fetched with the addresses that were fetched.
    */
   onFetchAccounts?: (addresses: Address[]) => void;


### PR DESCRIPTION
## Summary

- **`AccountDecodeError`** (new in `@macalinao/gill-extra`, re-exported by `@macalinao/grill`): decoder failures are wrapped with the account's `address`, `programAddress` (owner), and data length, with the original error preserved as `.cause` — so a failure traces to a specific on-chain account instead of an opaque "index out of bounds"-style message. `useAccount`/`useAccounts` decode failures now surface as this error on the query's `error` state.
- **Subscription decode guarding**: a malformed `accountNotifications` update is logged (with address/owner context) and skipped, keeping the last good value in the cache and the subscription running instead of tearing it down.
- **`createBatchAccountsLoader` now defaults to `cache: false`**, making it a pure request coalescer. Previously DataLoader's permanent per-address cache silently shadowed React Query: `invalidateQueries`, `refetch()`, `staleTime`, etc. would re-run the query only to replay stale bytes. React Query is now the single source of truth; pass `cache: true` to restore the old memoizing behavior.
- **Batch fixes**: duplicate addresses within a batch are deduped so they don't burn slots against the 99-account limit, and a failed chunk now returns one `Error` per key (DataLoader requires exactly one result per key — previously a single `Error` misaligned the results array).
- **New `useRefetchAccount()` / `useRefetchAccounts()` hooks**, plus README docs on refreshing account data via `createAccountQueryKey` from anywhere a `QueryClient` is available.

Includes a minor changeset for `@macalinao/solana-batch-accounts-loader`, `@macalinao/gill-extra`, and `@macalinao/grill`.

## Test plan

- New tests in `createBatchAccountsLoader.test.ts` covering: no memoization across separate loads by default, concurrent same-address loads coalescing into one deduped RPC call, and opt-in `cache: true` memoization
- New `account-decode-error.test.ts` in gill-extra

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Guard account decode failures and align account caching so React Query is the single source of truth for on-chain account data.

New Features:
- Introduce AccountDecodeError to wrap decoder failures with account address, owner, and data length and re-export it from grill.
- Add useRefetchAccount and useRefetchAccounts hooks and document query-key based account refresh in the grill README.

Bug Fixes:
- Ensure batch account fetch failures return one Error per requested key to satisfy DataLoader's result alignment requirements.

Enhancements:
- Default createBatchAccountsLoader to a non-memoizing, request-coalescing mode with optional cache, deduplicating duplicate addresses within a batch.
- Guard subscription account decodes so malformed notifications are logged and skipped while preserving the last good cached value.
- Propagate AccountDecodeError through fetch-and-decode and subscription paths so decode issues surface with precise account context.

Documentation:
- Expand grill README with guidance on React Query as the account source of truth, query-key based invalidation, and usage of new refetch hooks and decode error handling.

Tests:
- Extend createBatchAccountsLoader tests to cover non-memoizing default behavior, concurrent coalescing, and opt-in memoization.
- Add unit tests for AccountDecodeError messaging and cause preservation.

Chores:
- Add a changeset bumping minor versions for solana-batch-accounts-loader, gill-extra, and grill to reflect decode guarding and caching changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added convenient hooks for refreshing one or multiple accounts.
  - Added `AccountDecodeError` with account and program context.
  - Added support for manually invalidating account data outside React.

- **Bug Fixes**
  - Account data now refreshes reliably after invalidation.
  - Decode failures are surfaced clearly in queries.
  - Malformed subscription updates are skipped without interrupting live updates.
  - Batch loading preserves result order and handles failed requests correctly.

- **Documentation**
  - Expanded guidance for refreshing accounts, token balances, cache behavior, and decode errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->