### PR TITLE
chore: upgrade @macalinao/tsconfig to v4

### DIFF
--- a/.changeset/tsconfig-v4-exact-optional.md
+++ b/.changeset/tsconfig-v4-exact-optional.md
@@ -1,0 +1,14 @@
+---
+"@macalinao/das-api": patch
+"@macalinao/gill-extra": patch
+"@macalinao/grill": patch
+"@macalinao/quarry": patch
+"@macalinao/react-quarry": patch
+"@macalinao/zod-solana": patch
+---
+
+Upgrade `@macalinao/tsconfig` to v4, which turns on `exactOptionalPropertyTypes` (plus `allowImportingTsExtensions`, `rewriteRelativeImportExtensions` and `moduleDetection: "force"`) in the base config.
+
+Optional properties on public option bags and DAS API response types are now declared as `?: T | undefined` rather than `?: T`. This matches what the zod schemas actually produce and what callers forwarding an optional value actually pass; it widens the accepted input, so it is not a breaking change for consumers.
+
+`tsconfig.strict.json` drops `erasableSyntaxOnly`, `noImplicitReturns` and `noUncheckedSideEffectImports`, which the v4 base config now enables on its own.

--- a/.changeset/tsconfig-v4-exact-optional.md
+++ b/.changeset/tsconfig-v4-exact-optional.md
@@ -12,3 +12,5 @@ Upgrade `@macalinao/tsconfig` to v4, which turns on `exactOptionalPropertyTypes`
 Optional properties on public option bags and DAS API response types are now declared as `?: T | undefined` rather than `?: T`. This matches what the zod schemas actually produce and what callers forwarding an optional value actually pass; it widens the accepted input, so it is not a breaking change for consumers.
 
 `tsconfig.strict.json` drops `erasableSyntaxOnly`, `noImplicitReturns` and `noUncheckedSideEffectImports`, which the v4 base config now enables on its own.
+
+`bunfig.toml` exempts `@macalinao/tsconfig` from the 7-day `minimumReleaseAge` soak. It is a first-party package, so the soak buys nothing; the 7-day default still applies to every other dependency.

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "oxfmt": "0.58.0",
         "oxlint": "1.73.0",
         "oxlint-tsgolint": "0.24.0",
-        "tsdown": "^0.22.5",
+        "tsdown": "^0.22.6",
         "turbo": "^2.10.4",
         "typescript": "^7.0.2",
         "unrun": "^0.3.1",
@@ -311,7 +311,7 @@
   },
   "catalog": {
     "@gillsdk/react": "^0.7.0",
-    "@macalinao/tsconfig": "^3.2.5",
+    "@macalinao/tsconfig": "^4.0.0",
     "@solana/kit": "^6.10.0",
     "@solana/wallet-adapter-base": "^0.9.27",
     "@solana/wallet-adapter-react": "^0.15.39",
@@ -559,7 +559,7 @@
 
     "@macalinao/token-utils": ["@macalinao/token-utils@workspace:packages/token-utils"],
 
-    "@macalinao/tsconfig": ["@macalinao/tsconfig@3.2.5", "", {}, "sha512-qtP+OqdAXhGZFjRs9VM7NfwIFQA2ufGdw6GBmhqmS7qBkeEf1gW5fa23j2/RxvyqBPSQhTgR2lNGhpbYn9IzgQ=="],
+    "@macalinao/tsconfig": ["@macalinao/tsconfig@4.0.0", "", {}, "sha512-XRDcRVQOkrl1j6eqXJncuMIewGEAjRORDCkQ3fibI1UVN3o8UvrbT7HtFVuAl8RK5QzCNwHaNTdyw/lIPXQCQw=="],
 
     "@macalinao/wallet-adapter-compat": ["@macalinao/wallet-adapter-compat@workspace:packages/wallet-adapter-compat"],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -3,3 +3,6 @@
 # published for at least 7 days, giving time for malicious or broken
 # releases to be caught and yanked before they reach this repo.
 minimumReleaseAge = 604800
+# First-party package (published from macalinao/style-guide), so the soak period
+# buys us nothing here — exempt it to avoid a week-long wait on our own releases.
+minimumReleaseAgeExcludes = ["@macalinao/tsconfig"]

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     },
     "catalog": {
       "typescript": "^7.0.2",
-      "@macalinao/tsconfig": "^3.2.5",
+      "@macalinao/tsconfig": "^4.0.0",
       "@solana/kit": "^6.10.0",
       "tslib": "^2.8.1",
       "@tanstack/react-query": "^5.101.2",

--- a/packages/das-api/src/types/asset-list.ts
+++ b/packages/das-api/src/types/asset-list.ts
@@ -8,9 +8,9 @@ export interface DasApiNativeBalance {
   /** The native balance, in lamports. */
   lamports: number;
   /** The price per SOL, if pricing data is available. */
-  price_per_sol?: number;
+  price_per_sol?: number | undefined;
   /** The total value of the native balance. */
-  total_price?: number;
+  total_price?: number | undefined;
 }
 
 /**
@@ -22,17 +22,17 @@ export interface DasApiAssetList {
   /** The limit that was used to build this page. */
   limit: number;
   /** The page number of this result, for page-based pagination. */
-  page?: number;
+  page?: number | undefined;
   /** The cursor pointing before this page, for cursor-based pagination. */
-  before?: string;
+  before?: string | undefined;
   /** The cursor pointing after this page, for cursor-based pagination. */
-  after?: string;
+  after?: string | undefined;
   /** An opaque cursor for cursor-based pagination. */
-  cursor?: string;
+  cursor?: string | undefined;
   /** The assets in this page. */
   items: DasApiAsset[];
   /** The owner's native balance, when `showNativeBalance` is enabled. */
-  nativeBalance?: DasApiNativeBalance;
+  nativeBalance?: DasApiNativeBalance | undefined;
   /** The grand total across all pages, when `showGrandTotal` is enabled. */
-  grand_total?: number;
+  grand_total?: number | undefined;
 }

--- a/packages/das-api/src/types/asset.ts
+++ b/packages/das-api/src/types/asset.ts
@@ -18,13 +18,13 @@ import type { JsonValue } from "./json-value.js";
  */
 export interface DasApiAssetFile {
   /** The URI of the file. */
-  uri?: string;
+  uri?: string | undefined;
   /** The MIME type of the file. */
-  mime?: string;
+  mime?: string | undefined;
   /** The CDN-hosted URI of the file, if available. */
-  cdn_uri?: string;
+  cdn_uri?: string | undefined;
   /** The rendering contexts the file applies to. */
-  contexts?: string[];
+  contexts?: string[] | undefined;
 }
 
 /**
@@ -32,11 +32,11 @@ export interface DasApiAssetFile {
  */
 export interface DasApiMetadataAttribute {
   /** The trait type/category. */
-  trait_type?: string;
+  trait_type?: string | undefined;
   /** The trait value. */
-  value?: string | number;
+  value?: string | number | undefined;
   /** A hint for how the value should be displayed. */
-  display_type?: string;
+  display_type?: string | undefined;
 }
 
 /**
@@ -48,11 +48,11 @@ export interface DasApiMetadata {
   /** The symbol of the asset. */
   symbol: string;
   /** A description of the asset. */
-  description?: string;
+  description?: string | undefined;
   /** The Metaplex token standard, if applicable. */
-  token_standard?: string;
+  token_standard?: string | undefined;
   /** The attributes/traits of the asset. */
-  attributes?: DasApiMetadataAttribute[];
+  attributes?: DasApiMetadataAttribute[] | undefined;
 }
 
 /**
@@ -60,11 +60,11 @@ export interface DasApiMetadata {
  */
 export interface DasApiAssetLinks {
   /** The image URI. */
-  image?: string;
+  image?: string | undefined;
   /** The animation URI. */
-  animation_url?: string;
+  animation_url?: string | undefined;
   /** The external URI. */
-  external_url?: string;
+  external_url?: string | undefined;
 }
 
 /**
@@ -72,15 +72,15 @@ export interface DasApiAssetLinks {
  */
 export interface DasApiAssetContent {
   /** The JSON schema of the content. */
-  $schema?: string;
+  $schema?: string | undefined;
   /** The URI of the off-chain JSON metadata. */
   json_uri: string;
   /** The files referenced by the asset. */
-  files?: DasApiAssetFile[];
+  files?: DasApiAssetFile[] | undefined;
   /** The parsed off-chain metadata. */
   metadata: DasApiMetadata;
   /** Convenience links extracted from the metadata (e.g. image, animation). */
-  links?: DasApiAssetLinks;
+  links?: DasApiAssetLinks | undefined;
 }
 
 /**
@@ -106,11 +106,11 @@ export interface DasApiAssetCompression {
   /** The creator hash of the asset. */
   creator_hash: Address;
   /** The collection hash of the asset. */
-  collection_hash?: Address;
+  collection_hash?: Address | undefined;
   /** The asset data hash. */
-  asset_data_hash?: Address;
+  asset_data_hash?: Address | undefined;
   /** Bitflags describing the compressed asset. */
-  flags?: number;
+  flags?: number | undefined;
   /** The asset hash. */
   asset_hash: Address;
   /** The address of the merkle tree the asset belongs to. */
@@ -126,15 +126,15 @@ export interface DasApiAssetCompression {
  */
 export interface DasApiCollectionMetadata {
   /** The name of the collection. */
-  name?: string;
+  name?: string | undefined;
   /** The symbol of the collection. */
-  symbol?: string;
+  symbol?: string | undefined;
   /** The description of the collection. */
-  description?: string;
+  description?: string | undefined;
   /** The image URI of the collection. */
-  image?: string;
+  image?: string | undefined;
   /** The external URI of the collection. */
-  external_url?: string;
+  external_url?: string | undefined;
 }
 
 /**
@@ -146,9 +146,9 @@ export interface DasApiAssetGrouping {
   /** The value of the group (e.g. the collection address). */
   group_value: string;
   /** Whether the group membership is verified. */
-  verified?: boolean;
+  verified?: boolean | undefined;
   /** Collection metadata, present when `showCollectionMetadata` is enabled. */
-  collection_metadata?: DasApiCollectionMetadata;
+  collection_metadata?: DasApiCollectionMetadata | undefined;
 }
 
 /**
@@ -188,7 +188,7 @@ export interface DasApiAssetOwnership {
   /** Whether the asset is frozen. */
   frozen: boolean;
   /** Whether the asset is non-transferable. */
-  non_transferable?: boolean;
+  non_transferable?: boolean | undefined;
   /** Whether the asset is delegated. */
   delegated: boolean;
   /** The delegate address, if the asset is delegated. */
@@ -204,15 +204,15 @@ export interface DasApiAssetOwnership {
  */
 export interface DasApiAssetSupply {
   /** The maximum print supply. */
-  print_max_supply?: number;
+  print_max_supply?: number | undefined;
   /** The current print supply. */
-  print_current_supply?: number;
+  print_current_supply?: number | undefined;
   /** The edition nonce. */
-  edition_nonce?: number | null;
+  edition_nonce?: number | null | undefined;
   /** The address of the master edition, for printed editions. */
-  master_edition_mint?: Address;
+  master_edition_mint?: Address | undefined;
   /** The edition number, for printed editions. */
-  edition_number?: number;
+  edition_number?: number | undefined;
 }
 
 /**
@@ -234,9 +234,9 @@ export interface DasApiPriceInfo {
   /** The price per token. */
   price_per_token: number;
   /** The total price of the held balance. */
-  total_price?: number;
+  total_price?: number | undefined;
   /** The currency the price is denominated in. */
-  currency?: string;
+  currency?: string | undefined;
 }
 
 /**
@@ -244,23 +244,23 @@ export interface DasApiPriceInfo {
  */
 export interface DasApiTokenInfo {
   /** The symbol of the token. */
-  symbol?: string;
+  symbol?: string | undefined;
   /** The balance held by the queried owner, in base units. */
-  balance?: number;
+  balance?: number | undefined;
   /** The total supply of the token, in base units. */
-  supply?: number;
+  supply?: number | undefined;
   /** The number of decimals of the token. */
-  decimals?: number;
+  decimals?: number | undefined;
   /** The token program that owns the mint. */
-  token_program?: Address;
+  token_program?: Address | undefined;
   /** The associated token account for the queried owner. */
-  associated_token_address?: Address;
+  associated_token_address?: Address | undefined;
   /** Pricing information for the token. */
-  price_info?: DasApiPriceInfo;
+  price_info?: DasApiPriceInfo | undefined;
   /** The mint authority of the token. */
-  mint_authority?: Address;
+  mint_authority?: Address | undefined;
   /** The freeze authority of the token. */
-  freeze_authority?: Address;
+  freeze_authority?: Address | undefined;
 }
 
 /**
@@ -268,19 +268,19 @@ export interface DasApiTokenInfo {
  */
 export interface DasApiInscription {
   /** The inscription order. */
-  order?: number;
+  order?: number | undefined;
   /** The size of the inscription data, in bytes. */
-  size?: number;
+  size?: number | undefined;
   /** The content type of the inscription. */
-  contentType?: string;
+  contentType?: string | undefined;
   /** The encoding of the inscription. */
-  encoding?: string;
+  encoding?: string | undefined;
   /** The validation hash of the inscription. */
-  validationHash?: string;
+  validationHash?: string | undefined;
   /** The account holding the inscription data. */
-  inscriptionDataAccount?: Address;
+  inscriptionDataAccount?: Address | undefined;
   /** The authority of the inscription. */
-  authority?: Address;
+  authority?: Address | undefined;
 }
 
 /**
@@ -300,15 +300,15 @@ export interface DasApiTransferFee {
  */
 export interface DasApiTransferFeeConfig {
   /** The authority that can change the fee config. */
-  transfer_fee_config_authority?: Address;
+  transfer_fee_config_authority?: Address | undefined;
   /** The authority that can withdraw withheld tokens. */
-  withdraw_withheld_authority?: Address;
+  withdraw_withheld_authority?: Address | undefined;
   /** The amount of withheld tokens. */
-  withheld_amount?: number;
+  withheld_amount?: number | undefined;
   /** The currently active transfer fee. */
-  older_transfer_fee?: DasApiTransferFee;
+  older_transfer_fee?: DasApiTransferFee | undefined;
   /** The pending transfer fee. */
-  newer_transfer_fee?: DasApiTransferFee;
+  newer_transfer_fee?: DasApiTransferFee | undefined;
 }
 
 /**
@@ -316,9 +316,9 @@ export interface DasApiTransferFeeConfig {
  */
 export interface DasApiTransferHook {
   /** The authority that can change the transfer hook program. */
-  authority?: Address;
+  authority?: Address | undefined;
   /** The transfer hook program id. */
-  program_id?: Address;
+  program_id?: Address | undefined;
 }
 
 /**
@@ -326,9 +326,9 @@ export interface DasApiTransferHook {
  */
 export interface DasApiMetadataPointer {
   /** The authority that can change the metadata address. */
-  authority?: Address;
+  authority?: Address | undefined;
   /** The address holding the token metadata. */
-  metadata_address?: Address;
+  metadata_address?: Address | undefined;
 }
 
 /**
@@ -336,11 +336,11 @@ export interface DasApiMetadataPointer {
  */
 export interface DasApiGroupPointer {
   /** The authority that can change the pointer. */
-  authority?: Address;
+  authority?: Address | undefined;
   /** The address of the group. */
-  group_address?: Address;
+  group_address?: Address | undefined;
   /** The address of the group member. */
-  member_address?: Address;
+  member_address?: Address | undefined;
 }
 
 /**
@@ -348,7 +348,7 @@ export interface DasApiGroupPointer {
  */
 export interface DasApiMintCloseAuthority {
   /** The authority that can close the mint. */
-  close_authority?: Address;
+  close_authority?: Address | undefined;
 }
 
 /**
@@ -356,7 +356,7 @@ export interface DasApiMintCloseAuthority {
  */
 export interface DasApiPermanentDelegate {
   /** The permanent delegate over every token account. */
-  delegate?: Address;
+  delegate?: Address | undefined;
 }
 
 /**
@@ -364,7 +364,7 @@ export interface DasApiPermanentDelegate {
  */
 export interface DasApiDefaultAccountState {
   /** The default state of new token accounts. */
-  state?: string;
+  state?: string | undefined;
 }
 
 /**
@@ -372,15 +372,15 @@ export interface DasApiDefaultAccountState {
  */
 export interface DasApiInterestBearingConfig {
   /** The authority that can change the interest rate. */
-  rate_authority?: Address;
+  rate_authority?: Address | undefined;
   /** The timestamp the config was initialized. */
-  initialization_timestamp?: number;
+  initialization_timestamp?: number | undefined;
   /** The average rate before the last update. */
-  pre_update_average_rate?: number;
+  pre_update_average_rate?: number | undefined;
   /** The timestamp of the last update. */
-  last_update_timestamp?: number;
+  last_update_timestamp?: number | undefined;
   /** The current interest rate, in basis points. */
-  current_rate?: number;
+  current_rate?: number | undefined;
 }
 
 /**
@@ -388,17 +388,17 @@ export interface DasApiInterestBearingConfig {
  */
 export interface DasApiTokenMetadataExtension {
   /** The authority that can change the metadata. */
-  update_authority?: Address;
+  update_authority?: Address | undefined;
   /** The mint the metadata belongs to. */
-  mint?: Address;
+  mint?: Address | undefined;
   /** The name of the token. */
-  name?: string;
+  name?: string | undefined;
   /** The symbol of the token. */
-  symbol?: string;
+  symbol?: string | undefined;
   /** The URI of the off-chain metadata. */
-  uri?: string;
+  uri?: string | undefined;
   /** Arbitrary additional metadata, as `[key, value]` pairs. */
-  additional_metadata?: [key: string, value: string][];
+  additional_metadata?: [key: string, value: string][] | undefined;
 }
 
 /**
@@ -409,21 +409,21 @@ export interface DasApiTokenMetadataExtension {
  * type additional extensions.
  */
 export interface DasApiMintExtensions {
-  confidential_transfer_account?: JsonValue;
-  confidential_transfer_mint?: JsonValue;
-  confidential_transfer_fee_config?: JsonValue;
-  default_account_state?: DasApiDefaultAccountState;
-  group_member_pointer?: DasApiGroupPointer;
-  group_pointer?: DasApiGroupPointer;
-  interest_bearing_config?: DasApiInterestBearingConfig;
-  metadata?: DasApiTokenMetadataExtension;
-  metadata_pointer?: DasApiMetadataPointer;
-  mint_close_authority?: DasApiMintCloseAuthority;
-  permanent_delegate?: DasApiPermanentDelegate;
-  token_group?: JsonValue;
-  token_group_member?: JsonValue;
-  transfer_fee_config?: DasApiTransferFeeConfig;
-  transfer_hook?: DasApiTransferHook;
+  confidential_transfer_account?: JsonValue | undefined;
+  confidential_transfer_mint?: JsonValue | undefined;
+  confidential_transfer_fee_config?: JsonValue | undefined;
+  default_account_state?: DasApiDefaultAccountState | undefined;
+  group_member_pointer?: DasApiGroupPointer | undefined;
+  group_pointer?: DasApiGroupPointer | undefined;
+  interest_bearing_config?: DasApiInterestBearingConfig | undefined;
+  metadata?: DasApiTokenMetadataExtension | undefined;
+  metadata_pointer?: DasApiMetadataPointer | undefined;
+  mint_close_authority?: DasApiMintCloseAuthority | undefined;
+  permanent_delegate?: DasApiPermanentDelegate | undefined;
+  token_group?: JsonValue | undefined;
+  token_group_member?: JsonValue | undefined;
+  transfer_fee_config?: DasApiTransferFeeConfig | undefined;
+  transfer_hook?: DasApiTransferHook | undefined;
 }
 
 /**
@@ -435,22 +435,24 @@ export interface DasApiMintExtensions {
  */
 export interface DasApiCoreAssetFields {
   /** Plugins active on the asset or collection. */
-  plugins?: Record<string, JsonValue>;
+  plugins?: Record<string, JsonValue> | undefined;
   /** External plugins active on the asset or collection. */
-  external_plugins?: JsonValue[];
+  external_plugins?: JsonValue[] | undefined;
   /** Plugins that were unknown to the indexer at the time of indexing. */
-  unknown_plugins?: JsonValue[];
+  unknown_plugins?: JsonValue[] | undefined;
   /** External plugins that were unknown to the indexer at the time of indexing. */
-  unknown_external_plugins?: JsonValue[];
+  unknown_external_plugins?: JsonValue[] | undefined;
   /** Additional indexed fields for Core assets or collections. */
-  mpl_core_info?: {
-    /** Number of assets minted into this collection (collections only). */
-    num_minted?: number;
-    /** Current number of assets in this collection (collections only). */
-    current_size?: number;
-    /** The version of the plugins JSON schema. */
-    plugins_json_version?: number;
-  };
+  mpl_core_info?:
+    | undefined
+    | {
+        /** Number of assets minted into this collection (collections only). */
+        num_minted?: number | undefined;
+        /** Current number of assets in this collection (collections only). */
+        current_size?: number | undefined;
+        /** The version of the plugins JSON schema. */
+        plugins_json_version?: number | undefined;
+      };
 }
 
 /**
@@ -479,21 +481,21 @@ export interface DasApiAsset extends DasApiCoreAssetFields {
   /** Ownership information for the asset. */
   ownership: DasApiAssetOwnership;
   /** "Uses" information for the asset, if any. */
-  uses?: DasApiUses;
+  uses?: DasApiUses | undefined;
   /** Supply information for the asset, if any. */
-  supply?: DasApiAssetSupply | null;
+  supply?: DasApiAssetSupply | null | undefined;
   /** Whether the asset's metadata is mutable. */
   mutable: boolean;
   /** Whether the asset has been burnt. */
   burnt: boolean;
   /** Token information for a fungible asset (Helius extension). */
-  token_info?: DasApiTokenInfo;
+  token_info?: DasApiTokenInfo | undefined;
   /** Token-2022 mint extensions (Helius extension). */
-  mint_extensions?: DasApiMintExtensions;
+  mint_extensions?: DasApiMintExtensions | undefined;
   /** Inscription information (Helius extension). */
-  inscription?: DasApiInscription;
+  inscription?: DasApiInscription | undefined;
   /** SPL-20 data (Helius extension). */
-  spl20?: Record<string, JsonValue>;
+  spl20?: Record<string, JsonValue> | undefined;
   /** The most recent slot at which the asset was indexed (Helius extension). */
-  last_indexed_slot?: number;
+  last_indexed_slot?: number | undefined;
 }

--- a/packages/das-api/src/types/common.ts
+++ b/packages/das-api/src/types/common.ts
@@ -98,17 +98,17 @@ export interface DasApiAssetSorting {
  */
 export interface DasApiPagination {
   /** Sorting criteria for the results. */
-  sortBy?: DasApiAssetSorting;
+  sortBy?: DasApiAssetSorting | undefined;
   /** The maximum number of assets to retrieve (max 1000). */
-  limit?: number;
+  limit?: number | undefined;
   /** The index of the page to retrieve. The first page has index `1`. */
-  page?: number;
+  page?: number | undefined;
   /** Retrieve assets before the specified `id` value. */
-  before?: string;
+  before?: string | undefined;
   /** Retrieve assets after the specified `id` value. */
-  after?: string;
+  after?: string | undefined;
   /** An opaque cursor for cursor-based pagination. */
-  cursor?: string;
+  cursor?: string | undefined;
 }
 
 /**
@@ -120,17 +120,17 @@ export interface DasApiPagination {
  */
 export interface DasApiDisplayOptions {
   /** Include assets that belong to unverified collections. */
-  showUnverifiedCollections?: boolean;
+  showUnverifiedCollections?: boolean | undefined;
   /** Include full collection metadata in the `grouping` field. */
-  showCollectionMetadata?: boolean;
+  showCollectionMetadata?: boolean | undefined;
   /** Include fungible tokens in the results. */
-  showFungible?: boolean;
+  showFungible?: boolean | undefined;
   /** Include inscription and SPL-20 data. */
-  showInscription?: boolean;
+  showInscription?: boolean | undefined;
   /** Include the owner's native SOL balance (list methods only). */
-  showNativeBalance?: boolean;
+  showNativeBalance?: boolean | undefined;
   /** Include token accounts with a zero balance. */
-  showZeroBalance?: boolean;
+  showZeroBalance?: boolean | undefined;
   /** Include a grand total count across all pages (list methods only). */
-  showGrandTotal?: boolean;
+  showGrandTotal?: boolean | undefined;
 }

--- a/packages/das-api/src/types/nft-editions.ts
+++ b/packages/das-api/src/types/nft-editions.ts
@@ -21,17 +21,17 @@ export interface GetNftEditionsResponse {
   /** The limit that was used to build this page. */
   limit: number;
   /** The page number of this result. */
-  page?: number;
+  page?: number | undefined;
   /** The cursor pointing before this page. */
-  before?: string;
+  before?: string | undefined;
   /** The cursor pointing after this page. */
-  after?: string;
+  after?: string | undefined;
   /** The address of the master edition. */
   master_edition_address: Address;
   /** The mint of the master edition supply. */
   supply: number;
   /** The maximum supply of the master edition, if capped. */
-  max_supply?: number;
+  max_supply?: number | undefined;
   /** The printed editions in this page. */
   editions: DasApiNftEdition[];
 }

--- a/packages/das-api/src/types/signatures.ts
+++ b/packages/das-api/src/types/signatures.ts
@@ -14,13 +14,13 @@ export interface GetSignaturesForAssetResponse {
   /** The limit that was used to build this page. */
   limit: number;
   /** The page number of this result. */
-  page?: number;
+  page?: number | undefined;
   /** The cursor pointing before this page. */
-  before?: string;
+  before?: string | undefined;
   /** The cursor pointing after this page. */
-  after?: string;
+  after?: string | undefined;
   /** The id of the asset the signatures belong to. */
-  id?: string;
+  id?: string | undefined;
   /** The signatures, as `[signature, type]` tuples. */
   items: DasApiAssetSignature[];
 }

--- a/packages/das-api/src/types/token-accounts.ts
+++ b/packages/das-api/src/types/token-accounts.ts
@@ -14,15 +14,15 @@ export interface DasApiTokenAccount {
   /** The token amount held, in base units, as a string. */
   amount: number;
   /** The delegated amount, in base units. */
-  delegated_amount?: number;
+  delegated_amount?: number | undefined;
   /** Whether the token account is frozen. */
   frozen: boolean;
   /** The delegate of the token account, if any. */
-  delegate?: Address | null;
+  delegate?: Address | null | undefined;
   /** The close authority of the token account, if any. */
-  close_authority?: Address | null;
+  close_authority?: Address | null | undefined;
   /** The token extensions data, for Token-2022 accounts. */
-  token_extensions?: Record<string, JsonValue>;
+  token_extensions?: Record<string, JsonValue> | undefined;
 }
 
 /**
@@ -34,13 +34,13 @@ export interface GetTokenAccountsResponse {
   /** The limit that was used to build this page. */
   limit: number;
   /** The page number of this result. */
-  page?: number;
+  page?: number | undefined;
   /** The cursor pointing to the next page, for cursor-based pagination. */
-  cursor?: string;
+  cursor?: string | undefined;
   /** The cursor pointing before this page. */
-  before?: string;
+  before?: string | undefined;
   /** The cursor pointing after this page. */
-  after?: string;
+  after?: string | undefined;
   /** The token accounts in this page. */
   token_accounts: DasApiTokenAccount[];
 }

--- a/packages/gill-extra/src/build-get-explorer-link-function.ts
+++ b/packages/gill-extra/src/build-get-explorer-link-function.ts
@@ -145,7 +145,7 @@ export function buildGetExplorerLinkFunction(
       url.pathname = `/${paths.transaction}/${args.transaction}`;
     } else if ("address" in args && args.address) {
       url.pathname = `/${paths.address}/${args.address}`;
-    } else if ("block" in args && args.block !== undefined) {
+    } else if ("block" in args) {
       url.pathname = `/${paths.block}/${String(args.block)}`;
     }
 

--- a/packages/gill-extra/src/fetch-token-info.ts
+++ b/packages/gill-extra/src/fetch-token-info.ts
@@ -12,7 +12,7 @@ export interface FetchTokenInfoParams {
    * Whether to fetch from the certified token list as a fallback.
    * Defaults to true for backwards compatibility.
    */
-  fetchFromCertifiedTokenList?: boolean;
+  fetchFromCertifiedTokenList?: boolean | undefined;
 }
 
 /**

--- a/packages/gill-extra/src/log-transaction-simulation.ts
+++ b/packages/gill-extra/src/log-transaction-simulation.ts
@@ -39,12 +39,12 @@ export interface LogTransactionSimulationOptions {
   /**
    * The Solana cluster for explorer links.
    */
-  cluster?: SolanaCluster;
+  cluster?: SolanaCluster | undefined;
   /**
    * Custom RPC URL for the transaction inspector.
    * Required when using localhost or custom RPC endpoints.
    */
-  rpcUrl?: string;
+  rpcUrl?: string | undefined;
 }
 
 /**
@@ -74,7 +74,7 @@ export function createSimulationDebugBlock(options: {
   success: boolean;
   inspectorUrl: string;
   logs: string[];
-  errorMessage?: string;
+  errorMessage?: string | undefined;
 }): string {
   const { title, success, inspectorUrl, logs, errorMessage } = options;
 

--- a/packages/gill-extra/src/transaction.ts
+++ b/packages/gill-extra/src/transaction.ts
@@ -46,13 +46,13 @@ export interface TransactionInspectorUrlOptions {
    * The Solana cluster (defaults to "mainnet-beta").
    * Use "localnet" for local development with a custom RPC URL.
    */
-  cluster?: SolanaCluster;
+  cluster?: SolanaCluster | undefined;
   /**
    * Custom RPC URL for the transaction inspector.
    * Required when cluster is "localnet" or when using a custom RPC endpoint.
    * This will be URL-encoded and passed as the customUrl parameter.
    */
-  customUrl?: string;
+  customUrl?: string | undefined;
 }
 
 /**

--- a/packages/grill/src/hooks/use-account.ts
+++ b/packages/grill/src/hooks/use-account.ts
@@ -49,7 +49,7 @@ export interface UseAccountOptions {
    * // The pool data will automatically update when the on-chain state changes
    * ```
    */
-  subscribeToUpdates?: boolean;
+  subscribeToUpdates?: boolean | undefined;
 }
 
 export type UseAccountInput<

--- a/packages/grill/src/hooks/use-token-info.ts
+++ b/packages/grill/src/hooks/use-token-info.ts
@@ -59,6 +59,9 @@ export function useTokenInfo({
         (mintAccount !== undefined && metadataAccount !== undefined)),
     staleTime: staticInfo ? Number.POSITIVE_INFINITY : 5 * 60 * 1000, // Static info never goes stale
     gcTime: 60 * 60 * 1000, // Keep in cache for 1 hour
-    placeholderData: staticInfo ?? undefined,
+    // Spread conditionally: react-query types `placeholderData` without
+    // `| undefined`, so under exactOptionalPropertyTypes the key has to be absent
+    // rather than explicitly undefined (which would mean "no placeholder" anyway).
+    ...(staticInfo === undefined ? {} : { placeholderData: staticInfo }),
   });
 }

--- a/packages/grill/src/utils/internal/create-send-tx.test.ts
+++ b/packages/grill/src/utils/internal/create-send-tx.test.ts
@@ -33,7 +33,7 @@ const SIG_BYTES = new Uint8Array(64).fill(7) as SignatureBytes;
  * used so control-flow narrowing does not collapse the value to `undefined`
  * across the awaited `sendTX` call.
  */
-const polled: { lastValidBlockHeight?: bigint } = {};
+const polled: { lastValidBlockHeight?: bigint | undefined } = {};
 
 await mock.module("@macalinao/gill-extra", () => ({
   ...gillExtra,

--- a/packages/grill/src/utils/internal/create-send-tx.ts
+++ b/packages/grill/src/utils/internal/create-send-tx.ts
@@ -39,12 +39,12 @@ export interface CreateSendTXParams {
    * The RPC URL used for creating transaction inspector URLs.
    * This is needed to generate correct inspector URLs for custom RPC endpoints.
    */
-  rpcUrl?: string;
+  rpcUrl?: string | undefined;
   /**
    * The Solana cluster for explorer links.
    * Defaults to "mainnet-beta".
    */
-  cluster?: SolanaCluster;
+  cluster?: SolanaCluster | undefined;
 }
 
 /**
@@ -91,8 +91,15 @@ export const createSendTX = ({
       feePayer: signer,
       instructions: [...ixs],
       latestBlockhash,
-      computeUnitLimit: options.computeUnitLimit,
-      computeUnitPrice: options.computeUnitPrice,
+      // Spread conditionally: gill types these as `computeUnitLimit?: number | bigint`
+      // without `| undefined`, so under exactOptionalPropertyTypes the keys have to be
+      // absent rather than explicitly undefined.
+      ...(options.computeUnitLimit === undefined
+        ? {}
+        : { computeUnitLimit: options.computeUnitLimit }),
+      ...(options.computeUnitPrice === undefined
+        ? {}
+        : { computeUnitPrice: options.computeUnitPrice }),
     });
 
     // Apply address lookup tables if provided to compress the transaction

--- a/packages/quarry/src/ixs/merge-miner/create-withdraw-merge-miner-ixs.ts
+++ b/packages/quarry/src/ixs/merge-miner/create-withdraw-merge-miner-ixs.ts
@@ -26,7 +26,7 @@ export interface WithdrawMergeMinerArgs extends MergeMinerAmountArgs {
    *
    * Note: this must be a token account.
    */
-  tokenDestination?: Address;
+  tokenDestination?: Address | undefined;
 }
 
 /**

--- a/packages/react-quarry/src/hooks/use-quarry-withdraw-mm.ts
+++ b/packages/react-quarry/src/hooks/use-quarry-withdraw-mm.ts
@@ -7,7 +7,7 @@ import { usePoolInfo } from "../contexts/pool-info.js";
 
 export interface QuarryWithdrawMMArgs {
   amount: bigint;
-  tokenDestination?: Address;
+  tokenDestination?: Address | undefined;
 }
 
 export interface UseQuarryWithdrawMMResult {

--- a/packages/zod-solana/src/token-metadata-schema.ts
+++ b/packages/zod-solana/src/token-metadata-schema.ts
@@ -52,7 +52,7 @@ export interface TokenMetadataAttribute {
   /** The trait value (string or number) */
   value: string | number;
   /** Optional display type for UI formatting */
-  display_type?: string;
+  display_type?: string | undefined;
 }
 
 /**
@@ -64,7 +64,7 @@ export interface TokenMetadataFile {
   /** File MIME type */
   type: string;
   /** Whether the file is CDN cached */
-  cdn?: boolean;
+  cdn?: boolean | undefined;
 }
 
 /**
@@ -82,11 +82,11 @@ export interface TokenMetadataCreator {
  */
 export interface TokenMetadataProperties {
   /** Optional array of file references */
-  files?: TokenMetadataFile[];
+  files?: TokenMetadataFile[] | undefined;
   /** Optional category classification */
-  category?: string;
+  category?: string | undefined;
   /** Optional array of creators with royalty shares */
-  creators?: TokenMetadataCreator[];
+  creators?: TokenMetadataCreator[] | undefined;
 }
 
 /**
@@ -96,7 +96,7 @@ export interface TokenMetadataCollection {
   /** Collection name */
   name: string;
   /** Optional collection family */
-  family?: string;
+  family?: string | undefined;
 }
 
 /**
@@ -108,21 +108,21 @@ export interface TokenMetadata {
   /** The symbol of the token */
   symbol: string;
   /** Optional description of the token */
-  description?: string;
+  description?: string | undefined;
   /** Optional image URI */
-  image?: string;
+  image?: string | undefined;
   /** Optional animation URL for multimedia content */
-  animation_url?: string;
+  animation_url?: string | undefined;
   /** Optional external URL for additional information */
-  external_url?: string;
+  external_url?: string | undefined;
   /** Optional array of attributes/traits */
-  attributes?: TokenMetadataAttribute[];
+  attributes?: TokenMetadataAttribute[] | undefined;
   /** Optional properties object */
-  properties?: TokenMetadataProperties;
+  properties?: TokenMetadataProperties | undefined;
   /** Optional seller fee basis points (royalty percentage * 100) */
-  seller_fee_basis_points?: number;
+  seller_fee_basis_points?: number | undefined;
   /** Optional collection information */
-  collection?: TokenMetadataCollection;
+  collection?: TokenMetadataCollection | undefined;
 }
 
 /**

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -1,22 +1,23 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig.json",
-  // Strictness layered on top of @macalinao/tsconfig, which already enables
-  // `strict`, `noUncheckedIndexedAccess`, `noUnusedLocals`, `noUnusedParameters`,
-  // `noImplicitOverride`, `noFallthroughCasesInSwitch` and `isolatedDeclarations`.
+  // Strictness layered on top of @macalinao/tsconfig, which as of v4 already
+  // enables `strict`, `noUncheckedIndexedAccess`, `noUnusedLocals`,
+  // `noUnusedParameters`, `noImplicitOverride`, `noFallthroughCasesInSwitch`,
+  // `isolatedDeclarations`, `erasableSyntaxOnly`, `noImplicitReturns`,
+  // `noUncheckedSideEffectImports` and `exactOptionalPropertyTypes`.
   //
   // Every package extends this as the second entry of its `extends` array, so
   // these win over the base config. Anything listed here is enforced repo-wide.
   //
-  // `exactOptionalPropertyTypes` is deliberately NOT here: it does not survive
-  // contact with @tanstack/react-query's option objects (`placeholderData`,
-  // `enabled`), which would have to be passed via conditional spreads. See the
-  // PR that introduced this file for the full breakdown.
+  // `exactOptionalPropertyTypes` used to be deliberately excluded here because of
+  // @tanstack/react-query's option objects. tsconfig v4 turns it on in the base
+  // config, so it is now enforced: the handful of third-party option bags that
+  // type their optional keys without `| undefined` (react-query's
+  // `placeholderData`, gill's `computeUnitLimit`/`computeUnitPrice`) are passed
+  // via conditional spreads at the call site.
   "compilerOptions": {
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,
-    "erasableSyntaxOnly": true,
-    "noImplicitReturns": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noUncheckedSideEffectImports": true
+    "noPropertyAccessFromIndexSignature": true
   }
 }


### PR DESCRIPTION
Bumps the workspace catalog entry for `@macalinao/tsconfig` from `^3.2.5` to `^4.0.0`.

Every package consumes it via `catalog:`, so the only version edit is the one line in the root `package.json`.

`bun run build`, `bun run lint` (ast-grep + oxlint type-aware + oxfmt --check + tsc --noEmit) and `bun run test` all pass — verified uncached against a real 4.0.0 install.

## Release-age exemption

`@macalinao/tsconfig@4.0.0` was published 2026-08-01, and `bunfig.toml` enforces a 7-day `minimumReleaseAge` soak. That blocked resolution outright:

```
error: @macalinao/tsconfig@catalog: failed to resolve
```

`bun install --frozen-lockfile` (what CI runs) does **not** bypass the age check, and pinning the resolved version in `bun.lock` doesn't help either — so CI could not have installed this.

This PR adds `minimumReleaseAgeExcludes = ["@macalinao/tsconfig"]`, deliberately and at the maintainer's direction. `@macalinao/tsconfig` is a first-party package published by the repo owner from `macalinao/style-guide` — the soak exists to catch compromised or broken *third-party* releases, which is not the risk being run here.

**`minimumReleaseAge` itself is unchanged** — every other dependency still gets the full 7-day wait. This is a one-package exemption, not a weakening of the policy.

Verified that `bun install --frozen-lockfile` (the exact command CI runs) resolves 4.0.0 and exits 0, from a clean state with the installed copies deleted.

## What changed in v4

The base config now enables `exactOptionalPropertyTypes`, `allowImportingTsExtensions`, `rewriteRelativeImportExtensions` and `moduleDetection: "force"`. It also picks up `erasableSyntaxOnly`, `noImplicitReturns` and `noUncheckedSideEffectImports`, which this repo already enforced via `tsconfig.strict.json`.

In practice `exactOptionalPropertyTypes` accounts for essentially all of the fallout: **48 error sites** across 6 packages. The other three new options produced no errors — notably the `.ts`-extension import flags are permissive, so the existing `.js`-extension imports are unaffected.

## Categories of errors fixed

**1. Zod-backed response types** (`das-api`, `zod-solana`) — the bulk, ~35 sites.

Hand-written interfaces are checked against their schemas via `z.ZodType<T>`. They declared optional fields as `?: T`, but zod's `.optional()` produces `T | undefined` in the output type, which is no longer assignable. Declared them `?: T | undefined` to match what the schemas actually produce.

**2. Forwarded option bags** (`gill-extra`, `grill`, `quarry`, `react-quarry`).

Call sites that forward a possibly-undefined value straight through to a callee — `fetchFromCertifiedTokenList`, `rpcUrl`, `customUrl`, `errorMessage`, `subscribeToUpdates`, `cluster`, `tokenDestination`. The receiving interfaces now declare those keys `?: T | undefined`. This *widens* the accepted input, so it is not a breaking change for consumers, and reading the property is unchanged.

**3. Third-party option bags that can't be changed here.**

react-query's `placeholderData` and gill's `computeUnitLimit`/`computeUnitPrice` type their optional keys without `| undefined`, so the key has to be *absent* rather than explicitly undefined. Passed via conditional spreads at the call site, each with a comment explaining why.

**4. One newly-redundant condition** (`gill-extra`).

`build-get-explorer-link-function.ts` had `"block" in args && args.block !== undefined`. Under `exactOptionalPropertyTypes` the second half is provably always true, which tripped oxlint's `no-unnecessary-condition`. Dropped the redundant half; `"block" in args` alone still handles `block: 0` correctly (which is why it wasn't a truthiness check to begin with).

No `any`, `@ts-ignore`, non-null assertions, or loosened compiler options were used.

## Also

`tsconfig.strict.json` drops `erasableSyntaxOnly`, `noImplicitReturns` and `noUncheckedSideEffectImports` now that the v4 base enables them.

Its comment claiming `exactOptionalPropertyTypes` "does not survive contact with @tanstack/react-query's option objects (`placeholderData`, `enabled`)" turned out to be overstated, and is updated. Exactly one react-query site needed a conditional spread (`placeholderData` in `use-token-info.ts`); `enabled` was never a problem.

