### PR TITLE
fix(grill): keep account subscriptions alive across disconnects

### DIFF
--- a/.changeset/resilient-subscriptions.md
+++ b/.changeset/resilient-subscriptions.md
@@ -1,0 +1,12 @@
+---
+"@macalinao/grill": minor
+---
+
+Account subscriptions are now resilient to connection loss.
+
+- A subscription whose WebSocket errors out, or whose notification stream is closed by the server, is re-opened automatically with exponential backoff (equal jitter, capped at 30s) for as long as anyone is still subscribed. Previously the stream simply ended and the account silently stopped receiving updates.
+- Reconnect waits are cut short by the browser's `online` event, so regaining connectivity or waking from sleep resubscribes immediately instead of sitting out the backoff.
+- After a reconnect the account's query is invalidated, since notifications published while the socket was down are unrecoverable.
+- `createSubscriptionManager` accepts an optional `{ reconnect: { baseDelayMs, maxDelayMs, stableConnectionMs } }` config to tune the backoff.
+- `SubscriptionManager` gained `getSubscriptionStatus(address)`, returning `"connecting" | "connected" | "reconnecting"` for the address (or `undefined` when nothing is subscribed).
+- Unsubscribe functions are idempotent: calling one twice no longer drops a reference another subscriber still holds, which could tear down a live subscription.

--- a/apps/example-dapp/src/lib/grill-type-coverage.ts
+++ b/apps/example-dapp/src/lib/grill-type-coverage.ts
@@ -23,7 +23,10 @@ import type {
   PdaQueryKey,
   PdasHook,
   SubscriptionManager,
+  SubscriptionManagerOptions,
   SubscriptionProviderProps,
+  SubscriptionReconnectConfig,
+  SubscriptionStatus,
   TokenInfoQueryKey,
   TransactionId,
   TransactionStatusEvent,
@@ -102,6 +105,9 @@ export interface ProviderTypes {
 /** WebSocket subscription plumbing. */
 export interface SubscriptionTypes {
   manager: SubscriptionManager;
+  managerOptions: SubscriptionManagerOptions;
+  reconnect: SubscriptionReconnectConfig;
+  status: SubscriptionStatus;
   decoder: AccountDecoder<Mint>;
   data: AccountData;
 }

--- a/apps/example-dapp/src/routes/examples/subscriptions.tsx
+++ b/apps/example-dapp/src/routes/examples/subscriptions.tsx
@@ -3,6 +3,7 @@ import type {
   AccountDecoder,
   SubscriptionManager,
   SubscriptionProviderProps,
+  SubscriptionStatus,
 } from "@macalinao/grill";
 import type { Address } from "@solana/kit";
 import type { ReactNode } from "react";
@@ -76,6 +77,29 @@ const useLiveSubscriptionCount = (
   return count;
 };
 
+/** Same idea for the connection state, which moves on reconnects. */
+const useLiveSubscriptionStatus = (
+  manager: SubscriptionManager,
+  address: Address,
+): SubscriptionStatus | undefined => {
+  const [status, setStatus] = useState<SubscriptionStatus | undefined>(
+    undefined,
+  );
+
+  useEffect(() => {
+    const tick = () => {
+      setStatus(manager.getSubscriptionStatus(address));
+    };
+    tick();
+    const id = setInterval(tick, 500);
+    return () => {
+      clearInterval(id);
+    };
+  }, [manager, address]);
+
+  return status;
+};
+
 /**
  * `useAccountSubscription` — subscribe by hand, read with a separate hook.
  *
@@ -96,6 +120,7 @@ const ManualSubscriptionCard: React.FC = () => {
   });
 
   const count = useLiveSubscriptionCount(manager, SOL_USDC_POOL);
+  const status = useLiveSubscriptionStatus(manager, SOL_USDC_POOL);
 
   return (
     <Card>
@@ -103,7 +128,9 @@ const ManualSubscriptionCard: React.FC = () => {
         <CardTitle>useAccountSubscription</CardTitle>
         <CardDescription>
           Subscribing and reading are separate concerns. Toggle the subscription
-          and watch the manager’s reference count follow.
+          and watch the manager’s reference count follow. The socket re-opens
+          itself if the connection drops, so the status flips back to{" "}
+          <code className="font-mono">connected</code> on its own.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-3">
@@ -121,6 +148,12 @@ const ManualSubscriptionCard: React.FC = () => {
             getSubscriptionCount:{" "}
             <span className="font-mono font-medium text-foreground">
               {count}
+            </span>
+          </span>
+          <span className="text-sm text-muted-foreground">
+            getSubscriptionStatus:{" "}
+            <span className="font-mono font-medium text-foreground">
+              {status ?? "—"}
             </span>
           </span>
         </div>

--- a/packages/grill/src/contexts/subscription-context.test.ts
+++ b/packages/grill/src/contexts/subscription-context.test.ts
@@ -1,0 +1,405 @@
+import type { Address, Lamports } from "@solana/kit";
+import type { RpcSubscriptions, SolanaRpcSubscriptionsApi } from "gill";
+import type { AccountDecoder } from "./subscription-context.js";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { address, getBase64Decoder, lamports } from "@solana/kit";
+import { QueryClient } from "@tanstack/react-query";
+import { createAccountQueryKey } from "../query-keys.js";
+import { createSubscriptionManager } from "./subscription-context.js";
+
+const ACCOUNT = address("SysvarC1ock11111111111111111111111111111111");
+const OWNER = address("11111111111111111111111111111111");
+
+/** Reconnect fast enough that the tests do not have to wait on real backoff. */
+const FAST_RECONNECT = {
+  reconnect: { baseDelayMs: 1, maxDelayMs: 2, stableConnectionMs: 0 },
+};
+
+interface NotificationValue {
+  lamports: Lamports;
+  data: readonly [string, string];
+  owner: Address;
+  executable: boolean;
+  space: bigint;
+}
+
+interface Notification {
+  value: NotificationValue;
+}
+
+/** Builds an `accountNotifications` payload whose data decodes to `bytes`. */
+function makeNotification(bytes: Uint8Array, sol = 1n): Notification {
+  return {
+    value: {
+      lamports: lamports(sol),
+      data: [getBase64Decoder().decode(bytes), "base64"] as const,
+      owner: OWNER,
+      executable: false,
+      space: BigInt(bytes.length),
+    },
+  };
+}
+
+/**
+ * One WebSocket subscription's notification stream, driven by the test: push
+ * notifications, then either close it (server hung up) or fail it (socket
+ * error).
+ */
+interface FakeChannel {
+  abortSignal: AbortSignal;
+  push: (notification: Notification) => void;
+  close: () => void;
+  fail: (error: Error) => void;
+  iterable: AsyncIterable<Notification>;
+}
+
+function createFakeChannel(abortSignal: AbortSignal): FakeChannel {
+  const queue: Notification[] = [];
+  let wake: (() => void) | null = null;
+  let closed = false;
+  let failure: Error | null = null;
+
+  const flush = (): void => {
+    const resolve = wake;
+    wake = null;
+    resolve?.();
+  };
+
+  const iterable: AsyncIterable<Notification> = {
+    async *[Symbol.asyncIterator]() {
+      for (;;) {
+        const next = queue.shift();
+        if (next !== undefined) {
+          yield next;
+          continue;
+        }
+        if (failure) {
+          throw failure;
+        }
+        if (closed || abortSignal.aborted) {
+          return;
+        }
+        await new Promise<void>((resolve) => {
+          wake = resolve;
+          abortSignal.addEventListener("abort", flush, { once: true });
+        });
+      }
+    },
+  };
+
+  return {
+    abortSignal,
+    iterable,
+    push: (notification) => {
+      queue.push(notification);
+      flush();
+    },
+    close: () => {
+      closed = true;
+      flush();
+    },
+    fail: (error) => {
+      failure = error;
+      flush();
+    },
+  };
+}
+
+interface FakeRpcSubscriptions {
+  rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+  /** Every channel handed out, in the order they were subscribed. */
+  channels: FakeChannel[];
+  /** Errors to reject the next `subscribe()` calls with, one per entry. */
+  subscribeErrors: Error[];
+}
+
+function createFakeRpcSubscriptions(): FakeRpcSubscriptions {
+  const channels: FakeChannel[] = [];
+  const subscribeErrors: Error[] = [];
+
+  const rpcSubscriptions = {
+    accountNotifications: () => ({
+      subscribe: ({
+        abortSignal,
+      }: {
+        abortSignal: AbortSignal;
+      }): Promise<AsyncIterable<Notification>> => {
+        const error = subscribeErrors.shift();
+        if (error) {
+          return Promise.reject(error);
+        }
+        const channel = createFakeChannel(abortSignal);
+        channels.push(channel);
+        return Promise.resolve(channel.iterable);
+      },
+    }),
+  };
+
+  return {
+    rpcSubscriptions:
+      rpcSubscriptions as unknown as RpcSubscriptions<SolanaRpcSubscriptionsApi>,
+    channels,
+    subscribeErrors,
+  };
+}
+
+interface DecodedAccount {
+  address: Address;
+  bytes: number[];
+}
+
+const decoder: AccountDecoder<DecodedAccount> = (encodedAccount) => ({
+  ...encodedAccount,
+  data: {
+    address: encodedAccount.address,
+    bytes: [...encodedAccount.data],
+  },
+});
+
+async function waitFor(
+  predicate: () => boolean,
+  message: string,
+  timeoutMs = 2000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) {
+      throw new Error(`Timed out waiting for ${message}`);
+    }
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 2);
+    });
+  }
+}
+
+const queryKey = createAccountQueryKey(ACCOUNT);
+
+function readCachedBytes(queryClient: QueryClient): number[] | undefined {
+  const cached = queryClient.getQueryData<{ data: DecodedAccount }>(queryKey);
+  return cached?.data.bytes;
+}
+
+describe("createSubscriptionManager", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient();
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  it("writes decoded notifications into the account query cache", async () => {
+    const rpc = createFakeRpcSubscriptions();
+    const manager = createSubscriptionManager(
+      rpc.rpcSubscriptions,
+      queryClient,
+      FAST_RECONNECT,
+    );
+
+    const unsubscribe = manager.subscribe(ACCOUNT, decoder);
+    await waitFor(() => rpc.channels.length === 1, "the first subscription");
+
+    rpc.channels[0]?.push(makeNotification(new Uint8Array([1, 2, 3])));
+    await waitFor(
+      () => readCachedBytes(queryClient) !== undefined,
+      "an update",
+    );
+
+    expect(readCachedBytes(queryClient)).toEqual([1, 2, 3]);
+    expect(manager.getSubscriptionStatus(ACCOUNT)).toBe("connected");
+
+    unsubscribe();
+  });
+
+  it("clears the cache entry when the account is closed on-chain", async () => {
+    const rpc = createFakeRpcSubscriptions();
+    const manager = createSubscriptionManager(
+      rpc.rpcSubscriptions,
+      queryClient,
+      FAST_RECONNECT,
+    );
+
+    const unsubscribe = manager.subscribe(ACCOUNT, decoder);
+    await waitFor(() => rpc.channels.length === 1, "the first subscription");
+
+    rpc.channels[0]?.push(makeNotification(new Uint8Array([9]), 0n));
+    await waitFor(
+      () => queryClient.getQueryData(queryKey) === null,
+      "the closure to land",
+    );
+
+    unsubscribe();
+  });
+
+  it("re-opens the subscription when the server closes the stream", async () => {
+    const rpc = createFakeRpcSubscriptions();
+    const manager = createSubscriptionManager(
+      rpc.rpcSubscriptions,
+      queryClient,
+      FAST_RECONNECT,
+    );
+
+    const unsubscribe = manager.subscribe(ACCOUNT, decoder);
+    await waitFor(() => rpc.channels.length === 1, "the first subscription");
+
+    // The server hangs up. Previously this ended the subscription for good.
+    rpc.channels[0]?.close();
+    await waitFor(() => rpc.channels.length === 2, "a reconnect");
+
+    // The replacement stream feeds the same cache entry.
+    rpc.channels[1]?.push(makeNotification(new Uint8Array([7, 7])));
+    await waitFor(
+      () => readCachedBytes(queryClient) !== undefined,
+      "an update after reconnecting",
+    );
+    expect(readCachedBytes(queryClient)).toEqual([7, 7]);
+
+    unsubscribe();
+  });
+
+  it("re-opens the subscription when the stream errors", async () => {
+    const consoleError = spyOn(console, "error").mockImplementation(() => {
+      // The manager logs the dropped connection; keep the test output clean.
+    });
+
+    try {
+      const rpc = createFakeRpcSubscriptions();
+      const manager = createSubscriptionManager(
+        rpc.rpcSubscriptions,
+        queryClient,
+        FAST_RECONNECT,
+      );
+
+      const unsubscribe = manager.subscribe(ACCOUNT, decoder);
+      await waitFor(() => rpc.channels.length === 1, "the first subscription");
+
+      rpc.channels[0]?.fail(new Error("socket closed unexpectedly"));
+      await waitFor(() => rpc.channels.length === 2, "a reconnect");
+
+      rpc.channels[1]?.push(makeNotification(new Uint8Array([4])));
+      await waitFor(
+        () => readCachedBytes(queryClient) !== undefined,
+        "an update after reconnecting",
+      );
+
+      unsubscribe();
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("keeps retrying when the subscribe call itself fails", async () => {
+    const consoleError = spyOn(console, "error").mockImplementation(() => {
+      // Expected: two failed connection attempts are logged.
+    });
+
+    try {
+      const rpc = createFakeRpcSubscriptions();
+      rpc.subscribeErrors.push(
+        new Error("connect failed"),
+        new Error("connect failed again"),
+      );
+
+      const manager = createSubscriptionManager(
+        rpc.rpcSubscriptions,
+        queryClient,
+        FAST_RECONNECT,
+      );
+      const unsubscribe = manager.subscribe(ACCOUNT, decoder);
+
+      await waitFor(
+        () => rpc.channels.length === 1,
+        "a connection after two failures",
+      );
+
+      rpc.channels[0]?.push(makeNotification(new Uint8Array([5])));
+      await waitFor(
+        () => readCachedBytes(queryClient) !== undefined,
+        "an update once connected",
+      );
+
+      unsubscribe();
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("invalidates the cached account after reconnecting", async () => {
+    const rpc = createFakeRpcSubscriptions();
+    const manager = createSubscriptionManager(
+      rpc.rpcSubscriptions,
+      queryClient,
+      FAST_RECONNECT,
+    );
+
+    // Stand in for the read that `useAccount` would have populated.
+    queryClient.setQueryData(queryKey, {
+      data: { address: ACCOUNT, bytes: [] },
+    });
+
+    const unsubscribe = manager.subscribe(ACCOUNT, decoder);
+    await waitFor(() => rpc.channels.length === 1, "the first subscription");
+    expect(queryClient.getQueryState(queryKey)?.isInvalidated).toBe(false);
+
+    rpc.channels[0]?.close();
+    await waitFor(() => rpc.channels.length === 2, "a reconnect");
+
+    // Updates published while the socket was down are unrecoverable, so the
+    // cached account has to be refetched.
+    await waitFor(
+      () => queryClient.getQueryState(queryKey)?.isInvalidated === true,
+      "the account query to be invalidated",
+    );
+
+    unsubscribe();
+  });
+
+  it("stops reconnecting once the last subscriber unsubscribes", async () => {
+    const rpc = createFakeRpcSubscriptions();
+    const manager = createSubscriptionManager(
+      rpc.rpcSubscriptions,
+      queryClient,
+      FAST_RECONNECT,
+    );
+
+    const unsubscribe = manager.subscribe(ACCOUNT, decoder);
+    await waitFor(() => rpc.channels.length === 1, "the first subscription");
+
+    unsubscribe();
+    expect(rpc.channels[0]?.abortSignal.aborted).toBe(true);
+    expect(manager.getSubscriptionCount(ACCOUNT)).toBe(0);
+    expect(manager.getSubscriptionStatus(ACCOUNT)).toBeUndefined();
+
+    rpc.channels[0]?.close();
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 25);
+    });
+    expect(rpc.channels).toHaveLength(1);
+  });
+
+  it("shares one subscription and tolerates repeated unsubscribes", async () => {
+    const rpc = createFakeRpcSubscriptions();
+    const manager = createSubscriptionManager(
+      rpc.rpcSubscriptions,
+      queryClient,
+      FAST_RECONNECT,
+    );
+
+    const first = manager.subscribe(ACCOUNT, decoder);
+    const second = manager.subscribe(ACCOUNT, decoder);
+    await waitFor(() => rpc.channels.length === 1, "the first subscription");
+    expect(manager.getSubscriptionCount(ACCOUNT)).toBe(2);
+
+    // A double release must not drop the reference the other subscriber holds.
+    first();
+    first();
+    expect(manager.getSubscriptionCount(ACCOUNT)).toBe(1);
+    expect(rpc.channels[0]?.abortSignal.aborted).toBe(false);
+
+    second();
+    expect(manager.getSubscriptionCount(ACCOUNT)).toBe(0);
+    expect(rpc.channels[0]?.abortSignal.aborted).toBe(true);
+  });
+});

--- a/packages/grill/src/contexts/subscription-context.ts
+++ b/packages/grill/src/contexts/subscription-context.ts
@@ -54,12 +54,65 @@ export function createAccountDecoderFromDecoder<
 }
 
 /**
+ * Connection state of a single account subscription.
+ *
+ * - `connecting`: the initial `accountNotifications` subscribe is in flight.
+ * - `connected`: notifications are streaming.
+ * - `reconnecting`: the stream ended or errored and a retry is scheduled.
+ */
+export type SubscriptionStatus = "connecting" | "connected" | "reconnecting";
+
+/**
+ * Tuning for how a dropped subscription is re-established.
+ */
+export interface SubscriptionReconnectConfig {
+  /**
+   * Delay before the first reconnect attempt, in milliseconds. Doubles on each
+   * consecutive failure, up to {@link maxDelayMs}.
+   *
+   * @default 500
+   */
+  baseDelayMs?: number;
+  /**
+   * Upper bound on the delay between reconnect attempts, in milliseconds.
+   *
+   * @default 30000
+   */
+  maxDelayMs?: number;
+  /**
+   * How long a connection must survive before it is considered healthy, in
+   * milliseconds. Dropping after this long resets the backoff, so an
+   * occasional disconnect reconnects promptly instead of inheriting the delay
+   * from an unrelated outage hours earlier.
+   *
+   * @default 30000
+   */
+  stableConnectionMs?: number;
+}
+
+/**
+ * Options for {@link createSubscriptionManager}.
+ */
+export interface SubscriptionManagerOptions {
+  /**
+   * Reconnection tuning. Subscriptions always reconnect; this only controls
+   * how aggressively.
+   */
+  reconnect?: SubscriptionReconnectConfig;
+}
+
+const DEFAULT_BASE_DELAY_MS = 500;
+const DEFAULT_MAX_DELAY_MS = 30_000;
+const DEFAULT_STABLE_CONNECTION_MS = 30_000;
+
+/**
  * Internal subscription entry tracking the WebSocket subscription and reference count.
  */
 interface SubscriptionEntry {
   abortController: AbortController;
   refCount: number;
   decoder: AccountDecoder<AccountData>;
+  status: SubscriptionStatus;
 }
 
 /**
@@ -89,6 +142,10 @@ export interface SubscriptionManager {
    *
    * Multiple calls with the same address will share a single WebSocket subscription.
    * The subscription is automatically cleaned up when all subscribers unsubscribe.
+   *
+   * The subscription is resilient: if the WebSocket drops or the server closes
+   * the stream, it is re-established with exponential backoff until the last
+   * subscriber unsubscribes.
    */
   subscribe: <T extends AccountData>(
     address: Address,
@@ -99,6 +156,12 @@ export interface SubscriptionManager {
    * Get the current reference count for an address (for debugging).
    */
   getSubscriptionCount: (address: Address) => number;
+
+  /**
+   * Get the connection state for an address, or `undefined` if nothing is
+   * subscribed to it (for debugging).
+   */
+  getSubscriptionStatus: (address: Address) => SubscriptionStatus | undefined;
 }
 
 /**
@@ -123,59 +186,217 @@ function parseAccountNotification(
 }
 
 /**
+ * Backoff delay for the given number of consecutive failures, with equal
+ * jitter so that a fleet of subscriptions dropped by one outage does not
+ * reconnect in lockstep.
+ */
+function getReconnectDelayMs(
+  failedAttempts: number,
+  baseDelayMs: number,
+  maxDelayMs: number,
+): number {
+  const exponential = Math.min(
+    maxDelayMs,
+    baseDelayMs * 2 ** Math.min(failedAttempts, 30),
+  );
+  return exponential / 2 + Math.random() * (exponential / 2);
+}
+
+/**
+ * Waits `delayMs` before the next reconnect attempt, resolving early when the
+ * subscription is torn down or when the browser reports the network coming
+ * back. Waking from sleep or regaining connectivity should not have to sit out
+ * the remainder of a 30 second backoff.
+ */
+function waitBeforeReconnect(
+  delayMs: number,
+  abortSignal: AbortSignal,
+): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const canListenForOnline =
+      typeof globalThis.addEventListener === "function";
+
+    let settled = false;
+    const finish = (): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      abortSignal.removeEventListener("abort", finish);
+      if (canListenForOnline) {
+        globalThis.removeEventListener("online", finish);
+      }
+      resolve();
+    };
+
+    const timeout = setTimeout(finish, delayMs);
+    abortSignal.addEventListener("abort", finish, { once: true });
+    if (canListenForOnline) {
+      globalThis.addEventListener("online", finish);
+    }
+  });
+}
+
+/**
  * Creates a subscription manager instance.
+ *
+ * Subscriptions created by this manager survive connection loss: when the
+ * underlying WebSocket errors out or the server closes the notification
+ * stream, the manager reconnects with exponential backoff (waking early on the
+ * browser's `online` event) and invalidates the account's query so the updates
+ * missed while disconnected are picked up.
  */
 export function createSubscriptionManager(
   rpcSubscriptions: RpcSubscriptionsType,
   queryClient: QueryClient,
+  options: SubscriptionManagerOptions = {},
 ): SubscriptionManager {
+  const {
+    baseDelayMs = DEFAULT_BASE_DELAY_MS,
+    maxDelayMs = DEFAULT_MAX_DELAY_MS,
+    stableConnectionMs = DEFAULT_STABLE_CONNECTION_MS,
+  } = options.reconnect ?? {};
+
   const subscriptions = new Map<string, SubscriptionEntry>();
 
-  const setupSubscription = async <T extends AccountData>(
+  const applyNotification = (
     address: Address,
-    decoder: AccountDecoder<T>,
-    abortSignal: AbortSignal,
-  ): Promise<void> => {
+    decoder: AccountDecoder<AccountData>,
+    value: AccountNotificationValue,
+  ): void => {
     try {
-      const accountNotifications = await rpcSubscriptions
-        .accountNotifications(address, {
-          commitment: "confirmed",
-          encoding: "base64",
-        })
-        .subscribe({ abortSignal });
-
-      for await (const notification of accountNotifications) {
-        try {
-          const value =
-            notification.value as unknown as AccountNotificationValue;
-
-          // Handle account closure (lamports = 0)
-          if (value.lamports === 0n) {
-            queryClient.setQueryData(createAccountQueryKey(address), null);
-            continue;
-          }
-
-          // Parse and decode, then update cache
-          const encodedAccount = parseAccountNotification(address, value);
-          const decoded = decoder(encodedAccount);
-          queryClient.setQueryData(createAccountQueryKey(address), decoded);
-        } catch (decodeError) {
-          console.error(
-            `[SubscriptionManager] Error decoding account ${address}:`,
-            decodeError,
-          );
-        }
-      }
-    } catch (error) {
-      // AbortError is expected when unsubscribing
-      if (error instanceof Error && error.name === "AbortError") {
+      // Handle account closure (lamports = 0)
+      if (value.lamports === 0n) {
+        queryClient.setQueryData(createAccountQueryKey(address), null);
         return;
       }
+
+      // Parse and decode, then update cache
+      const encodedAccount = parseAccountNotification(address, value);
+      const decoded = decoder(encodedAccount);
+      queryClient.setQueryData(createAccountQueryKey(address), decoded);
+    } catch (decodeError) {
       console.error(
-        `[SubscriptionManager] Subscription error for ${address}:`,
-        error,
+        `[SubscriptionManager] Error decoding account ${address}:`,
+        decodeError,
       );
     }
+  };
+
+  /**
+   * Keeps an account subscription open for as long as anyone is subscribed.
+   *
+   * Each iteration of the loop opens one WebSocket subscription and drains it.
+   * The loop only exits when the entry's `AbortController` fires, which
+   * happens when the last subscriber unsubscribes -- every other exit path
+   * (server closing the stream, socket error, failed subscribe) is a
+   * reconnect.
+   */
+  const runSubscription = async (
+    address: Address,
+    entry: SubscriptionEntry,
+    abortSignal: AbortSignal,
+  ): Promise<void> => {
+    let failedAttempts = 0;
+    let hasConnected = false;
+
+    // `AbortSignal.aborted` is a readonly property, so TypeScript narrows it to
+    // `false` for the rest of the loop body once the `while` condition has been
+    // checked. Reading it through a call keeps every later check meaningful.
+    const isAborted = (): boolean => abortSignal.aborted;
+
+    while (!isAborted()) {
+      let connectedAt: number | null = null;
+
+      try {
+        const accountNotifications = await rpcSubscriptions
+          .accountNotifications(address, {
+            commitment: "confirmed",
+            encoding: "base64",
+          })
+          .subscribe({ abortSignal });
+
+        entry.status = "connected";
+        connectedAt = Date.now();
+
+        // Notifications sent while the socket was down are gone for good, so
+        // the cached account cannot be trusted after a reconnect. Refetch it.
+        if (hasConnected) {
+          void queryClient.invalidateQueries({
+            queryKey: createAccountQueryKey(address),
+          });
+        }
+        hasConnected = true;
+
+        for await (const notification of accountNotifications) {
+          applyNotification(address, entry.decoder, notification.value);
+        }
+
+        // Draining the iterator to completion means the server closed the
+        // notification stream on us.
+      } catch (error) {
+        // AbortError is expected when unsubscribing.
+        if (isAborted()) {
+          return;
+        }
+        console.error(
+          `[SubscriptionManager] Subscription error for ${address}, reconnecting:`,
+          error,
+        );
+      }
+
+      if (isAborted()) {
+        return;
+      }
+
+      // A connection that stayed up for a while was healthy; do not punish the
+      // reconnect with backoff accumulated from an unrelated earlier outage.
+      if (
+        connectedAt !== null &&
+        Date.now() - connectedAt >= stableConnectionMs
+      ) {
+        failedAttempts = 0;
+      }
+
+      entry.status = "reconnecting";
+      await waitBeforeReconnect(
+        getReconnectDelayMs(failedAttempts, baseDelayMs, maxDelayMs),
+        abortSignal,
+      );
+      failedAttempts++;
+
+      if (isAborted()) {
+        return;
+      }
+      entry.status = "connecting";
+    }
+  };
+
+  const createUnsubscribe = (
+    key: string,
+    entry: SubscriptionEntry,
+  ): (() => void) => {
+    // Unsubscribing twice must not drop the reference count twice, otherwise a
+    // subscription that other components still depend on gets torn down.
+    let released = false;
+
+    return () => {
+      if (released) {
+        return;
+      }
+      released = true;
+
+      entry.refCount--;
+      if (entry.refCount <= 0) {
+        entry.abortController.abort();
+        // Only clear the slot if it still holds this entry -- a later
+        // subscribe may already have installed a replacement.
+        if (subscriptions.get(key) === entry) {
+          subscriptions.delete(key);
+        }
+      }
+    };
   };
 
   const subscribe = <T extends AccountData>(
@@ -188,13 +409,7 @@ export function createSubscriptionManager(
     if (existing) {
       // Increment reference count for existing subscription
       existing.refCount++;
-      return () => {
-        existing.refCount--;
-        if (existing.refCount === 0) {
-          existing.abortController.abort();
-          subscriptions.delete(key);
-        }
-      };
+      return createUnsubscribe(key, existing);
     }
 
     // Create new subscription
@@ -203,25 +418,22 @@ export function createSubscriptionManager(
       abortController,
       refCount: 1,
       decoder,
+      status: "connecting",
     };
     subscriptions.set(key, entry);
 
-    // Start the WebSocket subscription
-    void setupSubscription(address, decoder, abortController.signal);
+    // Start the WebSocket subscription. The loop reconnects on its own; only a
+    // bug in the manager itself can reject here.
+    void runSubscription(address, entry, abortController.signal).catch(
+      (error: unknown) => {
+        console.error(
+          `[SubscriptionManager] Subscription loop for ${address} stopped:`,
+          error,
+        );
+      },
+    );
 
-    // Return unsubscribe function
-    return () => {
-      const currentEntry = subscriptions.get(key);
-      if (!currentEntry) {
-        return;
-      }
-
-      currentEntry.refCount--;
-      if (currentEntry.refCount === 0) {
-        currentEntry.abortController.abort();
-        subscriptions.delete(key);
-      }
-    };
+    return createUnsubscribe(key, entry);
   };
 
   const getSubscriptionCount = (address: Address): number => {
@@ -229,9 +441,14 @@ export function createSubscriptionManager(
     return entry?.refCount ?? 0;
   };
 
+  const getSubscriptionStatus = (
+    address: Address,
+  ): SubscriptionStatus | undefined => subscriptions.get(address)?.status;
+
   return {
     subscribe,
     getSubscriptionCount,
+    getSubscriptionStatus,
   };
 }
 


### PR DESCRIPTION
## Problem

`createSubscriptionManager` consumed each account's notification stream exactly once:

```ts
const accountNotifications = await rpcSubscriptions.accountNotifications(...).subscribe({ abortSignal });
for await (const notification of accountNotifications) { ... }
```

When the WebSocket errored, or the server closed the stream (idle timeout, RPC node restart, laptop sleep, network blip), the loop ended and `setupSubscription` resolved. The subscription was never re-opened — the account silently stopped receiving updates for the rest of the session, while `getSubscriptionCount` still reported a live subscriber. Anything relying on `subscribeToUpdates: true` quietly went stale.

## Fix

Each subscription now runs in a reconnect loop that only exits when its `AbortController` fires (i.e. when the last subscriber unsubscribes). Every other exit path — server closing the stream, socket error, a failed `subscribe()` — is a reconnect.

- **Exponential backoff with equal jitter**, from 500ms up to 30s, so a whole app's subscriptions dropped by one outage don't reconnect in lockstep. The backoff resets after a connection that stayed healthy for 30s.
- **Waking early on `online`**, so regaining connectivity or waking from sleep resubscribes immediately instead of sitting out the remainder of a 30s wait.
- **Invalidating the account query on reconnect** — notifications published while the socket was down can't be replayed, so the cached account is refetched. Not done on the initial connect, where the read has just happened.
- **`getSubscriptionStatus(address)`** returns `"connecting" | "connected" | "reconnecting"`, alongside the existing `getSubscriptionCount`.
- **Idempotent unsubscribe.** Calling an unsubscribe function twice used to decrement the shared reference count twice, which could tear down a subscription other components still depended on.
- **`createSubscriptionManager(rpc, queryClient, { reconnect: { baseDelayMs, maxDelayMs, stableConnectionMs } })`** for tuning. Defaults are sane; the third argument is optional.

## Tests

New `packages/grill/src/contexts/subscription-context.test.ts` drives the manager against a fake `rpcSubscriptions` whose streams the test can close or fail at will: reconnect after a server close, after a stream error, and after repeated `subscribe()` failures; cache invalidation on reconnect; no reconnect after the last unsubscribe; and reference-count sharing with a double release.

`bun run build`, `bun run lint`, and `bun run test` all pass.

## Demo

The subscriptions example page now shows `getSubscriptionStatus` next to the reference count.

## Summary by Sourcery

Make account WebSocket subscriptions resilient to connection loss and expose their connection status for debugging and demos.

New Features:
- Introduce subscription connection status tracking with the `SubscriptionStatus` type and `getSubscriptionStatus(address)` on `SubscriptionManager`.
- Add configurable reconnection tuning to `createSubscriptionManager` via `SubscriptionManagerOptions` and `SubscriptionReconnectConfig`, with sensible defaults.

Bug Fixes:
- Ensure account subscriptions automatically reconnect with backoff after server closes streams, socket errors, or failed subscribe calls, and stop once the final subscriber unsubscribes.
- Make unsubscribe functions idempotent so repeated calls do not incorrectly decrement the shared reference count and tear down active subscriptions.

Enhancements:
- Invalidate the associated account query after a reconnect so cached data is refreshed when notifications were missed during disconnection.
- Adjust the example subscriptions demo to display live connection status alongside the subscription reference count.

Documentation:
- Add a changeset entry documenting resilient subscriptions, reconnection behavior, configuration options, status reporting, and idempotent unsubscribe semantics.

Tests:
- Add a comprehensive subscription-context test suite that verifies reconnect behavior, cache updates and invalidation, unsubscribe semantics, and reference-count sharing under various failure scenarios.