### PR TITLE
perf: make zod and error message tables optional in bundles

### DIFF
--- a/.changeset/inline-chunk.md
+++ b/.changeset/inline-chunk.md
@@ -1,0 +1,5 @@
+---
+"@macalinao/solana-batch-accounts-loader": patch
+---
+
+Drop the `lodash-es` dependency by inlining the one `chunk` call it was used for. This roughly halves the package's bundled size (~4.9 KB to ~2.5 KB minified) with no behaviour change.

--- a/.changeset/optional-error-messages.md
+++ b/.changeset/optional-error-messages.md
@@ -1,0 +1,20 @@
+---
+"@macalinao/solana-errors": minor
+---
+
+Allow the human-readable error message tables to be stripped from production bundles.
+
+Define `__GRILL_ERROR_MESSAGES__` as `false` in your bundler to drop them:
+
+```ts
+// vite.config.ts
+export default defineConfig({
+  define: { __GRILL_ERROR_MESSAGES__: "false" },
+});
+```
+
+With the flag set, `getInstructionErrorMessage` and `getTransactionErrorMessage` report the variant name (e.g. `Transaction error: BlockhashNotFound`) instead of its prose description, and both message tables are dropped as dead code — ~8 KB down to ~1.7 KB minified.
+
+Messages remain enabled by default, so this is opt-in and existing behaviour is unchanged. The tables are only dropped if you do not import `INSTRUCTION_ERROR_MESSAGES` or `TRANSACTION_ERROR_MESSAGES` directly. A new `ERROR_MESSAGES_ENABLED` export exposes the resolved flag.
+
+Note that this relies on your bundler re-running dead-code elimination after constant folding: Rollup, rolldown, and Vite do, but plain esbuild and `bun build` do not.

--- a/.changeset/optional-token-metadata-validation.md
+++ b/.changeset/optional-token-metadata-validation.md
@@ -1,0 +1,21 @@
+---
+"@macalinao/gill-extra": minor
+"@macalinao/zod-solana": minor
+"@macalinao/grill": minor
+---
+
+Make token metadata validation pluggable so zod is no longer pulled into every bundle.
+
+- `fetchTokenInfo` and `fetchTokenInfoForMint` accept a new `validateMetadata` option, and `GrillProvider`/`GrillHeadlessProvider` accept a matching `validateTokenMetadata` prop.
+- The default is `defaultTokenMetadataValidator` (exported from `@macalinao/gill-extra`), a dependency-free shallow check that requires `name` and `symbol` to be strings and passes through the well-known optional string fields.
+- To keep full Metaplex schema validation, pass `zodTokenMetadataValidator` from `@macalinao/zod-solana`:
+
+  ```tsx
+  import { zodTokenMetadataValidator } from "@macalinao/zod-solana";
+
+  <GrillProvider validateTokenMetadata={zodTokenMetadataValidator}>
+  ```
+
+Importing `useTokenInfo` no longer drags zod into the bundle: it drops from ~70 KB to ~13 KB minified for apps that do not otherwise use zod.
+
+Note the behaviour change in the default path: nested fields (`attributes`, `properties`, `collection`) and `seller_fee_basis_points` are no longer validated and are omitted from the parsed result. Supply `zodTokenMetadataValidator` if you depend on them.

--- a/bun.lock
+++ b/bun.lock
@@ -311,6 +311,7 @@
   "overrides": {
     "@solana/kit": "^7.0.0",
     "@types/react": "catalog:",
+    "lodash-es": "^4.18.1",
     "react": "catalog:",
     "react-dom": "catalog:",
   },
@@ -2168,7 +2169,7 @@
 
     "lodash": ["lodash@4.17.21", "", {}, "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="],
 
-    "lodash-es": ["lodash-es@4.17.21", "", {}, "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="],
+    "lodash-es": ["lodash-es@4.18.1", "", {}, "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="],
 
     "lodash.isequal": ["lodash.isequal@4.5.0", "", {}, "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -219,14 +219,12 @@
       "version": "0.4.0",
       "dependencies": {
         "@macalinao/dataloader-es": "workspace:^",
-        "lodash-es": "^4.17.22",
         "tslib": "catalog:",
       },
       "devDependencies": {
         "@macalinao/tsconfig": "catalog:",
         "@solana/kit": "catalog:",
         "@types/bun": "catalog:",
-        "@types/lodash-es": "^4.17.12",
         "tsdown": "catalog:",
         "typescript": "catalog:",
       },
@@ -1300,10 +1298,6 @@
 
     "@types/jsesc": ["@types/jsesc@2.5.1", "", {}, "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw=="],
 
-    "@types/lodash": ["@types/lodash@4.17.20", "", {}, "sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA=="],
-
-    "@types/lodash-es": ["@types/lodash-es@4.17.12", "", { "dependencies": { "@types/lodash": "*" } }, "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ=="],
-
     "@types/node": ["@types/node@24.9.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg=="],
 
     "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
@@ -2174,7 +2168,7 @@
 
     "lodash": ["lodash@4.17.21", "", {}, "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="],
 
-    "lodash-es": ["lodash-es@4.18.1", "", {}, "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="],
+    "lodash-es": ["lodash-es@4.17.21", "", {}, "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="],
 
     "lodash.isequal": ["lodash.isequal@4.5.0", "", {}, "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="],
 
@@ -3039,8 +3033,6 @@
     "@tanstack/router-utils/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
 
     "@toruslabs/openlogin-jrpc/readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
-
-    "@toruslabs/solana-embed/lodash-es": ["lodash-es@4.17.21", "", {}, "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="],
 
     "@trezor/analytics/@trezor/utils": ["@trezor/utils@9.4.3", "", { "dependencies": { "bignumber.js": "^9.3.1" }, "peerDependencies": { "tslib": "^2.6.2" } }, "sha512-QkLHpGTF3W3wNGj6OCdcMog7MhAAdlUmpjjmMjMqE0JSoi1Yjr0m7k7xN0iIHSqcgrhYteZDeJZAGlAf/b7gqw=="],
 

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "@types/react": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "@solana/kit": "^7.0.0"
+    "@solana/kit": "^7.0.0",
+    "lodash-es": "^4.18.1"
   }
 }

--- a/packages/gill-extra/src/fetch-token-info-for-mint.ts
+++ b/packages/gill-extra/src/fetch-token-info-for-mint.ts
@@ -37,6 +37,7 @@ export async function fetchTokenInfoForMint({
   rpc,
   mint,
   fetchFromCertifiedTokenList,
+  validateMetadata,
 }: FetchTokenInfoForMintParams): Promise<TokenInfo> {
   // Find the metadata PDA
   const [metadataPda] = await findMetadataPda({
@@ -71,5 +72,6 @@ export async function fetchTokenInfoForMint({
     mint: mintAccount,
     metadata,
     fetchFromCertifiedTokenList,
+    validateMetadata,
   });
 }

--- a/packages/gill-extra/src/fetch-token-info.ts
+++ b/packages/gill-extra/src/fetch-token-info.ts
@@ -1,9 +1,10 @@
 import type { Metadata } from "@macalinao/clients-token-metadata";
 import type { TokenInfo } from "@macalinao/token-utils";
 import type { Mint } from "@solana-program/token";
+import type { TokenMetadataValidator } from "./token-metadata-validator.js";
 import type { AccountInfo } from "./types.js";
 import { createTokenInfo } from "@macalinao/token-utils";
-import { tokenMetadataSchema } from "@macalinao/zod-solana";
+import { defaultTokenMetadataValidator } from "./token-metadata-validator.js";
 
 export interface FetchTokenInfoParams {
   mint: AccountInfo<Pick<Mint, "decimals">>;
@@ -13,6 +14,14 @@ export interface FetchTokenInfoParams {
    * Defaults to true for backwards compatibility.
    */
   fetchFromCertifiedTokenList?: boolean | undefined;
+  /**
+   * Validates the JSON fetched from the token's metadata URI.
+   *
+   * Defaults to {@link defaultTokenMetadataValidator}, a dependency-free
+   * shallow check. Pass `zodTokenMetadataValidator` from
+   * `@macalinao/zod-solana` to validate the full Metaplex schema instead.
+   */
+  validateMetadata?: TokenMetadataValidator | undefined;
 }
 
 /**
@@ -24,6 +33,7 @@ export async function fetchTokenInfo({
   mint,
   metadata,
   fetchFromCertifiedTokenList = true,
+  validateMetadata = defaultTokenMetadataValidator,
 }: FetchTokenInfoParams): Promise<TokenInfo> {
   const uri = metadata?.data.uri;
   const decimals = mint.data.decimals;
@@ -51,19 +61,19 @@ export async function fetchTokenInfo({
           metadataUriJson = { image: uri };
         } else {
           // Otherwise, try to parse it as JSON
-          const result = tokenMetadataSchema.safeParse(await response.json());
+          const parsed = validateMetadata(await response.json());
 
-          if (result.success) {
+          if (parsed) {
             // Override with data from URI JSON
             metadataAccountData = {
-              name: result.data.name,
-              symbol: result.data.symbol,
+              name: parsed.name,
+              symbol: parsed.symbol,
             };
-            if (result.data.image) {
-              metadataUriJson = { image: result.data.image };
+            if (parsed.image) {
+              metadataUriJson = { image: parsed.image };
             }
           } else {
-            console.error("Invalid token metadata:", result.error);
+            console.error("Invalid token metadata at URI:", uri);
           }
         }
       }

--- a/packages/gill-extra/src/index.ts
+++ b/packages/gill-extra/src/index.ts
@@ -14,6 +14,7 @@ export * from "./get-solscan-explorer-link.js";
 export * from "./ixs/index.js";
 export * from "./log-transaction-simulation.js";
 export * from "./poll-confirm-transaction.js";
+export * from "./token-metadata-validator.js";
 export * from "./transaction.js";
 export * from "./transaction-error.js";
 export type * from "./types.js";

--- a/packages/gill-extra/src/token-metadata-validator.test.ts
+++ b/packages/gill-extra/src/token-metadata-validator.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "bun:test";
+import { defaultTokenMetadataValidator } from "./token-metadata-validator.js";
+
+describe("defaultTokenMetadataValidator", () => {
+  it("accepts metadata with the required fields", () => {
+    expect(
+      defaultTokenMetadataValidator({ name: "Solana", symbol: "SOL" }),
+    ).toEqual({
+      name: "Solana",
+      symbol: "SOL",
+      description: undefined,
+      image: undefined,
+      animation_url: undefined,
+      external_url: undefined,
+    });
+  });
+
+  it("passes through the well-known optional string fields", () => {
+    expect(
+      defaultTokenMetadataValidator({
+        name: "Solana",
+        symbol: "SOL",
+        description: "A token",
+        image: "https://example.com/sol.png",
+        animation_url: "https://example.com/sol.mp4",
+        external_url: "https://example.com",
+      }),
+    ).toEqual({
+      name: "Solana",
+      symbol: "SOL",
+      description: "A token",
+      image: "https://example.com/sol.png",
+      animation_url: "https://example.com/sol.mp4",
+      external_url: "https://example.com",
+    });
+  });
+
+  it("drops optional fields that are not strings", () => {
+    const result = defaultTokenMetadataValidator({
+      name: "Solana",
+      symbol: "SOL",
+      image: 42,
+    });
+    expect(result?.image).toBeUndefined();
+  });
+
+  it("rejects payloads missing name or symbol", () => {
+    expect(defaultTokenMetadataValidator({ symbol: "SOL" })).toBeNull();
+    expect(defaultTokenMetadataValidator({ name: "Solana" })).toBeNull();
+  });
+
+  it("rejects payloads whose name or symbol are not strings", () => {
+    expect(
+      defaultTokenMetadataValidator({ name: 1, symbol: "SOL" }),
+    ).toBeNull();
+    expect(
+      defaultTokenMetadataValidator({ name: "Solana", symbol: null }),
+    ).toBeNull();
+  });
+
+  it("rejects non-object payloads", () => {
+    expect(defaultTokenMetadataValidator(null)).toBeNull();
+    expect(defaultTokenMetadataValidator(undefined)).toBeNull();
+    expect(defaultTokenMetadataValidator("Solana")).toBeNull();
+    expect(defaultTokenMetadataValidator(42)).toBeNull();
+  });
+
+  it("does not surface unvalidated nested fields", () => {
+    const result = defaultTokenMetadataValidator({
+      name: "Solana",
+      symbol: "SOL",
+      attributes: "not-an-array",
+      collection: 12345,
+    });
+    expect(result).not.toBeNull();
+    expect(result).not.toHaveProperty("attributes");
+    expect(result).not.toHaveProperty("collection");
+  });
+});

--- a/packages/gill-extra/src/token-metadata-validator.ts
+++ b/packages/gill-extra/src/token-metadata-validator.ts
@@ -1,0 +1,60 @@
+import type { TokenMetadata } from "@macalinao/zod-solana";
+
+/**
+ * Validates the JSON served from a token's metadata URI.
+ *
+ * Returning `null` means the payload was not usable token metadata; the caller
+ * falls back to the on-chain metadata account.
+ *
+ * This is the seam that keeps zod out of the default bundle. The type is
+ * structural, so any function of this shape works — see
+ * {@link defaultTokenMetadataValidator} for the zero-dependency default, or
+ * `zodTokenMetadataValidator` from `@macalinao/zod-solana` for full schema
+ * validation.
+ */
+export type TokenMetadataValidator = (value: unknown) => TokenMetadata | null;
+
+const optionalString = (value: unknown): string | undefined =>
+  typeof value === "string" ? value : undefined;
+
+/**
+ * The default {@link TokenMetadataValidator}: a shallow structural check with no
+ * dependencies.
+ *
+ * It requires `name` and `symbol` to be strings and passes through the
+ * well-known optional string fields. Nested fields (`attributes`,
+ * `properties`, `collection`) and `seller_fee_basis_points` are *not* validated
+ * and are omitted from the result — if you need them, supply
+ * `zodTokenMetadataValidator` from `@macalinao/zod-solana` instead, which
+ * validates the full Metaplex schema at the cost of pulling zod into your
+ * bundle.
+ */
+export const defaultTokenMetadataValidator: TokenMetadataValidator = (
+  value,
+) => {
+  if (typeof value !== "object" || value === null) {
+    return null;
+  }
+
+  const {
+    name,
+    symbol,
+    description,
+    image,
+    animation_url: animationUrl,
+    external_url: externalUrl,
+  } = value as Record<string, unknown>;
+
+  if (typeof name !== "string" || typeof symbol !== "string") {
+    return null;
+  }
+
+  return {
+    name,
+    symbol,
+    description: optionalString(description),
+    image: optionalString(image),
+    animation_url: optionalString(animationUrl),
+    external_url: optionalString(externalUrl),
+  };
+};

--- a/packages/grill/src/contexts/grill-context.ts
+++ b/packages/grill/src/contexts/grill-context.ts
@@ -2,6 +2,7 @@ import type { DataLoader } from "@macalinao/dataloader-es";
 import type {
   GetExplorerLinkFunction,
   SendTXFunction,
+  TokenMetadataValidator,
 } from "@macalinao/gill-extra";
 import type { TokenInfo } from "@macalinao/token-utils";
 import type { Address, EncodedAccount } from "@solana/kit";
@@ -42,6 +43,11 @@ export interface GrillContextValue {
    * Defaults to true for backwards compatibility.
    */
   fetchFromCertifiedTokenList: boolean;
+
+  /**
+   * Validates the JSON fetched from a token's metadata URI.
+   */
+  validateTokenMetadata: TokenMetadataValidator;
 }
 
 /**

--- a/packages/grill/src/hooks/use-token-info.ts
+++ b/packages/grill/src/hooks/use-token-info.ts
@@ -23,7 +23,11 @@ export interface UseTokenInfoInput {
 export function useTokenInfo({
   mint,
 }: UseTokenInfoInput): UseQueryResult<TokenInfo | null> {
-  const { staticTokenInfo, fetchFromCertifiedTokenList } = useGrillContext();
+  const {
+    staticTokenInfo,
+    fetchFromCertifiedTokenList,
+    validateTokenMetadata,
+  } = useGrillContext();
   const { data: metadataAccount } = useTokenMetadataAccount({ mint });
   const { data: mintAccount } = useMintAccount({ address: mint });
 
@@ -51,6 +55,7 @@ export function useTokenInfo({
         mint: mintAccount,
         metadata: metadataAccount?.data ?? null,
         fetchFromCertifiedTokenList,
+        validateMetadata: validateTokenMetadata,
       });
     },
     enabled:

--- a/packages/grill/src/hooks/use-token-infos.ts
+++ b/packages/grill/src/hooks/use-token-infos.ts
@@ -34,7 +34,7 @@ export type UseTokenInfosResult =
 export function useTokenInfos({
   mints,
 }: UseTokenInfosInput): UseTokenInfosResult {
-  const { staticTokenInfo } = useGrillContext();
+  const { staticTokenInfo, validateTokenMetadata } = useGrillContext();
 
   // Filter out null/undefined mints for account fetching
   const validMints = mints?.filter((mint): mint is Address => !!mint) ?? [];
@@ -91,6 +91,7 @@ export function useTokenInfos({
           return fetchTokenInfo({
             mint: mintAccount,
             metadata: metadataAccount?.data ?? null,
+            validateMetadata: validateTokenMetadata,
           });
         },
         enabled:

--- a/packages/grill/src/providers/grill-headless-provider.tsx
+++ b/packages/grill/src/providers/grill-headless-provider.tsx
@@ -1,12 +1,14 @@
 import type {
   GetExplorerLinkFunction,
   SolanaCluster,
+  TokenMetadataValidator,
 } from "@macalinao/gill-extra";
 import type { TokenInfo } from "@macalinao/token-utils";
 import type { Address } from "gill";
 import type { FC, ReactNode } from "react";
 import type { TransactionStatusEventCallback } from "../types.js";
 import { useSolanaClient } from "@gillsdk/react";
+import { defaultTokenMetadataValidator } from "@macalinao/gill-extra";
 import { createBatchAccountsLoader } from "@macalinao/solana-batch-accounts-loader";
 import { useQueryClient } from "@tanstack/react-query";
 import { getExplorerLink as defaultGetExplorerLink } from "gill";
@@ -36,6 +38,15 @@ export interface GrillHeadlessProviderProps {
    * Defaults to true for backwards compatibility.
    */
   fetchFromCertifiedTokenList?: boolean;
+  /**
+   * Validates the JSON fetched from a token's metadata URI.
+   *
+   * Defaults to `defaultTokenMetadataValidator`, a dependency-free shallow
+   * check. Pass `zodTokenMetadataValidator` from `@macalinao/zod-solana` to
+   * validate the full Metaplex schema instead — note that doing so pulls zod
+   * into your bundle.
+   */
+  validateTokenMetadata?: TokenMetadataValidator;
   /**
    * The RPC URL used for creating transaction inspector URLs in error logs.
    * This is needed to generate correct inspector URLs for custom RPC endpoints.
@@ -73,6 +84,7 @@ export const GrillHeadlessProvider: FC<GrillHeadlessProviderProps> = ({
   getExplorerLink = defaultGetExplorerLink,
   staticTokenInfo = [],
   fetchFromCertifiedTokenList = true,
+  validateTokenMetadata = defaultTokenMetadataValidator,
   rpcUrl,
   cluster = "mainnet-beta",
 }) => {
@@ -138,6 +150,7 @@ export const GrillHeadlessProvider: FC<GrillHeadlessProviderProps> = ({
           getExplorerLink,
           staticTokenInfo: staticTokenInfoMap,
           fetchFromCertifiedTokenList,
+          validateTokenMetadata,
         }}
       >
         {children}

--- a/packages/solana-batch-accounts-loader/package.json
+++ b/packages/solana-batch-accounts-loader/package.json
@@ -46,14 +46,12 @@
   },
   "dependencies": {
     "@macalinao/dataloader-es": "workspace:^",
-    "lodash-es": "^4.17.22",
     "tslib": "catalog:"
   },
   "devDependencies": {
     "@macalinao/tsconfig": "catalog:",
     "@solana/kit": "catalog:",
     "@types/bun": "catalog:",
-    "@types/lodash-es": "^4.17.12",
     "tsdown": "catalog:",
     "typescript": "catalog:"
   },

--- a/packages/solana-batch-accounts-loader/src/createBatchAccountsLoader.ts
+++ b/packages/solana-batch-accounts-loader/src/createBatchAccountsLoader.ts
@@ -6,7 +6,20 @@ import type {
 } from "./types.js";
 import { DataLoader } from "@macalinao/dataloader-es";
 import { address, fetchEncodedAccounts } from "@solana/kit";
-import { chunk } from "lodash-es";
+
+/**
+ * Splits `items` into consecutive slices of at most `size`.
+ *
+ * Inlined rather than pulled from lodash-es: this is the only lodash usage in
+ * the package, and it accounted for roughly half of the package's bundled size.
+ */
+function chunk<T>(items: readonly T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}
 
 /**
  * Creates a DataLoader for batching Solana RPC account fetches.

--- a/packages/solana-errors/README.md
+++ b/packages/solana-errors/README.md
@@ -1,0 +1,62 @@
+# @macalinao/solana-errors
+
+Solana error message formatting that works in production.
+
+Unlike `@solana/errors`, which strips its message catalog when `__DEV__` is
+false, this package includes the full messages by default — so you can show
+users a real explanation rather than an error code.
+
+## Usage
+
+```ts
+import {
+  getInstructionErrorMessage,
+  getTransactionErrorMessage,
+} from "@macalinao/solana-errors";
+
+getTransactionErrorMessage("BlockhashNotFound");
+// "Blockhash not found in recent blockhashes or in the blockhash queue"
+
+getInstructionErrorMessage({ Custom: 6000 });
+// "Custom program error: 0x1770 (6000)"
+```
+
+## Stripping messages from your bundle
+
+The message tables cost roughly 6 KB minified. If you would rather ship error
+codes than prose, define `__GRILL_ERROR_MESSAGES__` as `false` and your bundler
+will drop them as dead code:
+
+```ts
+// vite.config.ts
+export default defineConfig({
+  define: { __GRILL_ERROR_MESSAGES__: "false" },
+});
+```
+
+```ts
+// webpack
+new webpack.DefinePlugin({ __GRILL_ERROR_MESSAGES__: false });
+```
+
+The functions then return the variant name instead of its description:
+
+```ts
+getTransactionErrorMessage("BlockhashNotFound");
+// "Transaction error: BlockhashNotFound"
+```
+
+Two caveats:
+
+- The tables are only dropped if you do not import `INSTRUCTION_ERROR_MESSAGES`
+  or `TRANSACTION_ERROR_MESSAGES` directly.
+- Your bundler has to re-run dead-code elimination after constant folding.
+  Rollup, rolldown, and Vite do. Plain esbuild and `bun build` fold the branch
+  but keep the now-unreferenced tables.
+
+`ERROR_MESSAGES_ENABLED` exports the resolved value of the flag if you need to
+branch on it yourself.
+
+## License
+
+Apache-2.0

--- a/packages/solana-errors/src/flags.ts
+++ b/packages/solana-errors/src/flags.ts
@@ -1,0 +1,39 @@
+/**
+ * Build-time flag controlling whether the human-readable error message tables
+ * are included in the bundle.
+ *
+ * The tables are ~7 KB minified. They are included by default. To strip them,
+ * define `__GRILL_ERROR_MESSAGES__` as `false` in your bundler:
+ *
+ * ```ts
+ * // vite.config.ts
+ * export default defineConfig({
+ *   define: { __GRILL_ERROR_MESSAGES__: "false" },
+ * });
+ * ```
+ *
+ * ```ts
+ * // esbuild / tsdown
+ * { define: { __GRILL_ERROR_MESSAGES__: "false" } }
+ * ```
+ *
+ * ```ts
+ * // webpack
+ * new webpack.DefinePlugin({ __GRILL_ERROR_MESSAGES__: false })
+ * ```
+ *
+ * With the flag defined as `false`, the ternary below folds to a constant, the
+ * table lookups become unreachable, and the tables are dropped as dead code.
+ * Errors then report their variant name (e.g. `Instruction error:
+ * InvalidArgument`) rather than a prose description.
+ *
+ * The `typeof` guard means an undefined identifier is safe: when the flag is
+ * not defined at all, `typeof` yields `"undefined"` rather than throwing a
+ * `ReferenceError`, and messages stay enabled.
+ */
+declare const __GRILL_ERROR_MESSAGES__: boolean | undefined;
+
+export const ERROR_MESSAGES_ENABLED: boolean =
+  typeof __GRILL_ERROR_MESSAGES__ === "boolean"
+    ? __GRILL_ERROR_MESSAGES__
+    : true;

--- a/packages/solana-errors/src/flags.ts
+++ b/packages/solana-errors/src/flags.ts
@@ -22,10 +22,16 @@
  * new webpack.DefinePlugin({ __GRILL_ERROR_MESSAGES__: false })
  * ```
  *
- * With the flag defined as `false`, the ternary below folds to a constant, the
- * table lookups become unreachable, and the tables are dropped as dead code.
- * Errors then report their variant name (e.g. `Instruction error:
- * InvalidArgument`) rather than a prose description.
+ * With the flag defined as `false`, the ternary below folds to a constant and
+ * the table lookups become unreachable. Errors then report their variant name
+ * (e.g. `Instruction error: InvalidArgument`) rather than a prose description.
+ *
+ * Whether the now-unreferenced tables actually leave the bundle is up to the
+ * consuming bundler: it has to re-run dead-code elimination after constant
+ * folding. Rollup, rolldown, and Vite do; plain esbuild and `bun build` fold
+ * the branch but keep the tables. This package ships unbundled, so
+ * `__GRILL_ERROR_MESSAGES__` survives into `dist/` for the consumer's `define`
+ * to replace. See the README for the full caveats.
  *
  * The `typeof` guard means an undefined identifier is safe: when the flag is
  * not defined at all, `typeof` yields `"undefined"` rather than throwing a

--- a/packages/solana-errors/src/index.ts
+++ b/packages/solana-errors/src/index.ts
@@ -9,6 +9,7 @@
  * applications.
  */
 
+export { ERROR_MESSAGES_ENABLED } from "./flags.js";
 export {
   getInstructionErrorMessage,
   INSTRUCTION_ERROR_MESSAGES,

--- a/packages/solana-errors/src/instruction-error.ts
+++ b/packages/solana-errors/src/instruction-error.ts
@@ -4,8 +4,13 @@
  * https://docs.rs/solana-program/latest/solana_program/instruction/enum.InstructionError.html
  */
 
+import { ERROR_MESSAGES_ENABLED } from "./flags.js";
+
 /**
  * InstructionError variant names mapped to their human-readable messages.
+ *
+ * Dropped from the bundle when `__GRILL_ERROR_MESSAGES__` is defined as
+ * `false`, provided you do not import this table directly.
  */
 export const INSTRUCTION_ERROR_MESSAGES: Record<string, string> = {
   // Generic/deprecated errors
@@ -95,7 +100,24 @@ function stringifyValue(value: unknown): string {
 }
 
 /**
+ * Looks up a variant's message, or returns `undefined` when message tables are
+ * disabled via `__GRILL_ERROR_MESSAGES__`.
+ *
+ * Routing every lookup through here is what lets bundlers drop
+ * {@link INSTRUCTION_ERROR_MESSAGES}: with the flag defined as `false` this
+ * folds to `undefined` and the table loses its last reference.
+ */
+function lookupInstructionErrorMessage(variant: string): string | undefined {
+  return ERROR_MESSAGES_ENABLED
+    ? INSTRUCTION_ERROR_MESSAGES[variant]
+    : undefined;
+}
+
+/**
  * Gets the human-readable message for an InstructionError.
+ *
+ * When message tables are stripped via `__GRILL_ERROR_MESSAGES__`, the variant
+ * name is returned instead of its prose description.
  *
  * @param error - The InstructionError value from the RPC response
  * @returns The formatted error message
@@ -107,7 +129,9 @@ export function getInstructionErrorMessage(error: unknown): string {
 
   // Handle string error (simple variant like "GenericError")
   if (typeof error === "string") {
-    return INSTRUCTION_ERROR_MESSAGES[error] ?? `Instruction error: ${error}`;
+    return (
+      lookupInstructionErrorMessage(error) ?? `Instruction error: ${error}`
+    );
   }
 
   // Handle object error (variant with data like { Custom: 1 } or { BorshIoError: "..." })
@@ -134,7 +158,7 @@ export function getInstructionErrorMessage(error: unknown): string {
 
     // For other variants with additional data
     const baseMessage =
-      INSTRUCTION_ERROR_MESSAGES[variant] ?? `Instruction error: ${variant}`;
+      lookupInstructionErrorMessage(variant) ?? `Instruction error: ${variant}`;
     if (value !== null && value !== undefined) {
       return `${baseMessage}: ${stringifyValue(value)}`;
     }

--- a/packages/solana-errors/src/transaction-error.ts
+++ b/packages/solana-errors/src/transaction-error.ts
@@ -5,12 +5,16 @@
  */
 
 import type { TransactionError } from "@solana/kit";
+import { ERROR_MESSAGES_ENABLED } from "./flags.js";
 import { getInstructionErrorMessage } from "./instruction-error.js";
 
 export type { TransactionError };
 
 /**
  * TransactionError variant names mapped to their human-readable messages.
+ *
+ * Dropped from the bundle when `__GRILL_ERROR_MESSAGES__` is defined as
+ * `false`, provided you do not import this table directly.
  */
 export const TRANSACTION_ERROR_MESSAGES: Record<string, string> = {
   AccountInUse: "Account is already being processed in another transaction",
@@ -67,7 +71,24 @@ export const TRANSACTION_ERROR_MESSAGES: Record<string, string> = {
 };
 
 /**
+ * Looks up a variant's message, or returns `undefined` when message tables are
+ * disabled via `__GRILL_ERROR_MESSAGES__`.
+ *
+ * Routing every lookup through here is what lets bundlers drop
+ * {@link TRANSACTION_ERROR_MESSAGES}: with the flag defined as `false` this
+ * folds to `undefined` and the table loses its last reference.
+ */
+function lookupTransactionErrorMessage(variant: string): string | undefined {
+  return ERROR_MESSAGES_ENABLED
+    ? TRANSACTION_ERROR_MESSAGES[variant]
+    : undefined;
+}
+
+/**
  * Gets the human-readable message for a TransactionError.
+ *
+ * When message tables are stripped via `__GRILL_ERROR_MESSAGES__`, the variant
+ * name is returned instead of its prose description.
  *
  * @param error - The TransactionError value from the RPC response
  * @returns The formatted error message
@@ -84,7 +105,7 @@ export function getTransactionErrorMessage(error: TransactionError): string {
 
   // Handle string error (simple variant like "AccountInUse")
   if (typeof raw === "string") {
-    return TRANSACTION_ERROR_MESSAGES[raw] ?? `Transaction error: ${raw}`;
+    return lookupTransactionErrorMessage(raw) ?? `Transaction error: ${raw}`;
   }
 
   // Handle object error (variant with data)
@@ -132,7 +153,7 @@ export function getTransactionErrorMessage(error: TransactionError): string {
 
     // For other variants
     const baseMessage =
-      TRANSACTION_ERROR_MESSAGES[variant] ?? `Transaction error: ${variant}`;
+      lookupTransactionErrorMessage(variant) ?? `Transaction error: ${variant}`;
     if (value !== null && value !== undefined && value !== true) {
       return `${baseMessage}: ${JSON.stringify(value)}`;
     }

--- a/packages/zod-solana/src/index.ts
+++ b/packages/zod-solana/src/index.ts
@@ -16,3 +16,4 @@ export { u32Schema } from "./u32-schema.js";
 export { u64Schema } from "./u64-schema.js";
 export { u64StringSchema } from "./u64-string-schema.js";
 export { jsonUint8ArraySchema, uint8ArraySchema } from "./uint8array-schema.js";
+export { zodTokenMetadataValidator } from "./zod-token-metadata-validator.js";

--- a/packages/zod-solana/src/zod-token-metadata-validator.ts
+++ b/packages/zod-solana/src/zod-token-metadata-validator.ts
@@ -1,0 +1,26 @@
+import type { TokenMetadata } from "./token-metadata-schema.js";
+import { tokenMetadataSchema } from "./token-metadata-schema.js";
+
+/**
+ * Validates token metadata URI JSON against the full Metaplex schema.
+ *
+ * Pass this to `fetchTokenInfo`/`fetchTokenInfoForMint` from
+ * `@macalinao/gill-extra` (or to `GrillProvider`'s `validateTokenMetadata`) to
+ * opt into full schema validation:
+ *
+ * ```ts
+ * import { zodTokenMetadataValidator } from "@macalinao/zod-solana";
+ *
+ * <GrillProvider validateTokenMetadata={zodTokenMetadataValidator}>
+ * ```
+ *
+ * Doing so pulls zod into your bundle. The default validator in gill-extra is
+ * a dependency-free shallow check; prefer it unless you rely on the nested
+ * fields (`attributes`, `properties`, `collection`) being validated.
+ */
+export const zodTokenMetadataValidator = (
+  value: unknown,
+): TokenMetadata | null => {
+  const result = tokenMetadataSchema.safeParse(value);
+  return result.success ? result.data : null;
+};


### PR DESCRIPTION
Three independent bundle-size reductions. All numbers are minified bytes measured with rolldown, with peer deps (`@solana/kit`, `@solana/*`, react, react-query, gill, sonner) marked external — so they are the *marginal* cost each package adds on top of what a consumer already pays.

| import | before | after |
|---|---|---|
| `useTokenInfo` | 70.4 KB | **13.2 KB** |
| `@macalinao/solana-batch-accounts-loader` | 4.9 KB | **2.5 KB** |
| `parseTransactionError` (with `__GRILL_ERROR_MESSAGES__=false`) | 8.0 KB | **1.7 KB** |

## 1. Pluggable token metadata validation

`fetchTokenInfo`/`fetchTokenInfoForMint` gained a `validateMetadata` option, and `GrillProvider`/`GrillHeadlessProvider` a matching `validateTokenMetadata` prop.

The default is `defaultTokenMetadataValidator` — a dependency-free shallow check. To keep full Metaplex schema validation:

```tsx
import { zodTokenMetadataValidator } from "@macalinao/zod-solana";

<GrillProvider validateTokenMetadata={zodTokenMetadataValidator}>
```

zod stays a first-class option; it is just no longer on the default path. `zod-solana` is unchanged apart from the new export.

**Behaviour change:** on the default path, nested fields (`attributes`, `properties`, `collection`) and `seller_fee_basis_points` are no longer validated and are omitted from the parsed result. `fetchTokenInfo` only ever read `name`, `symbol`, and `image`, so this does not affect `TokenInfo` — but it is visible to anyone passing a custom validator or relying on the parsed shape. Pass `zodTokenMetadataValidator` to restore the old behaviour exactly.

## 2. Inline `chunk`

`lodash-es` was pulled in for a single `chunk` call, and accounted for roughly half the package's bundled size. Now a 6-line local function; `lodash-es` and `@types/lodash-es` are removed from `package.json` and the lockfile.

## 3. Strippable error message tables

`@macalinao/solana-errors` deliberately ships full messages in production (that is the package's whole point), but there was no way to opt out. Now:

```ts
// vite.config.ts
export default defineConfig({
  define: { __GRILL_ERROR_MESSAGES__: "false" },
});
```

Lookups route through a helper gated on the flag, so defining it as `false` folds the branch to a constant and leaves both tables unreferenced. Errors then report the variant name (`Transaction error: BlockhashNotFound`) instead of prose.

Messages remain **on by default** — this is opt-in, existing behaviour is unchanged. Two caveats, both documented in the new README:

- The tables only drop if you do not import `INSTRUCTION_ERROR_MESSAGES` / `TRANSACTION_ERROR_MESSAGES` directly.
- Your bundler must re-run DCE after constant folding. Rollup, rolldown, and Vite do; plain esbuild and `bun build` fold the branch but keep the unreferenced tables.

## Notes

- Added `packages/solana-errors/README.md` — the package had none, and a build-time flag is useless if undiscoverable.
- 7 new tests for `defaultTokenMetadataValidator`. `lint`, `test`, and `build` all pass.
- Changesets: `gill-extra`/`zod-solana`/`grill` minor, `solana-errors` minor, `solana-batch-accounts-loader` patch.

### Pre-existing issue left alone

`useTokenInfos` does not forward `fetchFromCertifiedTokenList` to `fetchTokenInfo`, while `useTokenInfo` does — so setting it to `false` is ignored by the plural hook. Unrelated to this PR and fixing it changes behaviour, so I left it; happy to do it separately.

## Summary by Sourcery

Make token metadata validation pluggable and optional, inline the only lodash `chunk` usage, and add a build-time flag to optionally strip Solana error message tables from bundles.

New Features:
- Add pluggable token metadata validation with a default lightweight validator and an optional full zod-based validator.
- Introduce a build-time `__GRILL_ERROR_MESSAGES__` flag and `ERROR_MESSAGES_ENABLED` export to control inclusion of human-readable error messages.

Enhancements:
- Propagate configurable token metadata validation through Grill providers, context, and hooks to reduce default bundle size.
- Inline a local `chunk` helper in the Solana batch accounts loader and remove the `lodash-es` dependency to shrink the package.
- Document Solana error message behavior and configuration in a new README for `@macalinao/solana-errors`.

Build:
- Remove `lodash-es` and its type definitions from the Solana batch accounts loader package dependencies.

Tests:
- Add unit tests covering the behavior of the default token metadata validator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable token metadata validation with a lightweight default validator and optional full-schema validation.
  - Added build-time control to omit human-readable Solana error messages from production bundles.
  - Added an export indicating whether error messages are enabled.

- **Improvements**
  - Reduced batch account loader bundle size by removing an unnecessary dependency without changing behavior.
  - Simplified default metadata results by excluding unsupported nested fields.
  - Error formatting now falls back to variant names when messages are disabled.

- **Documentation**
  - Added guidance for error-message configuration and custom token metadata validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->