### PR TITLE
feat(zod-solana): add signatureSchema and blockhashSchema

### DIFF
--- a/.changeset/zod-solana-signature-blockhash.md
+++ b/.changeset/zod-solana-signature-blockhash.md
@@ -1,0 +1,7 @@
+---
+"@macalinao/zod-solana": minor
+---
+
+Add `signatureSchema` and `blockhashSchema` for validating base58-encoded Solana
+transaction signatures and blockhashes. Both parse a string and transform it into
+the corresponding branded `@solana/kit` type (`Signature` / `Blockhash`).

--- a/packages/zod-solana/README.md
+++ b/packages/zod-solana/README.md
@@ -104,7 +104,7 @@ type Wallet = z.infer<typeof walletSchema>;
 ## Features
 
 - ✅ **Type-safe**: Validates and transforms strings to Solana `Address` type
-- ✅ **Zod v3 & v4 compatible**: Works with both major versions of Zod
+- ✅ **Built for Zod v4**: Uses the Zod v4 schema typings (`zod: ^4` peer dependency)
 - ✅ **Comprehensive validation**: Checks for valid base58 encoding and address format
 - ✅ **TypeScript support**: Full type inference and autocompletion
 - ✅ **Framework agnostic**: Use with any JavaScript/TypeScript framework

--- a/packages/zod-solana/README.md
+++ b/packages/zod-solana/README.md
@@ -120,6 +120,22 @@ A Zod schema that validates Solana addresses.
 - **Output**: `Address` - A validated Address type from @solana/kit
 - **Errors**: Throws/returns error with message "Invalid Solana address" for invalid inputs
 
+### `signatureSchema`
+
+A Zod schema that validates Solana transaction signatures.
+
+- **Input**: `string` - A potential base58-encoded 64-byte signature
+- **Output**: `Signature` - A validated Signature type from @solana/kit
+- **Errors**: Throws/returns error with message "Invalid Solana signature" for invalid inputs
+
+### `blockhashSchema`
+
+A Zod schema that validates Solana blockhashes.
+
+- **Input**: `string` - A potential base58-encoded 32-byte blockhash
+- **Output**: `Blockhash` - A validated Blockhash type from @solana/kit
+- **Errors**: Throws/returns error with message "Invalid Solana blockhash" for invalid inputs
+
 ## Examples
 
 ### Validating Multiple Addresses

--- a/packages/zod-solana/src/address-schema.ts
+++ b/packages/zod-solana/src/address-schema.ts
@@ -1,22 +1,12 @@
 import type { Address } from "@solana/kit";
+import type * as z from "zod";
 import { address } from "@solana/kit";
-import * as z from "zod";
+import { createBrandedStringSchema } from "./create-branded-string-schema.js";
 
 /**
  * A Zod schema for Solana addresses.
  * Validates that a string is a valid Solana address and transforms it to an Address type.
  * Compatible with both Zod v3 and v4.
  */
-export const addressSchema: z.ZodType<Address, string> = z
-  .string()
-  .transform((val, ctx) => {
-    try {
-      return address(val);
-    } catch {
-      ctx.addIssue({
-        code: "custom",
-        message: "Invalid Solana address",
-      });
-      return z.NEVER;
-    }
-  });
+export const addressSchema: z.ZodType<Address, string> =
+  createBrandedStringSchema(address, "Invalid Solana address");

--- a/packages/zod-solana/src/address-schema.ts
+++ b/packages/zod-solana/src/address-schema.ts
@@ -6,7 +6,6 @@ import { createBrandedStringSchema } from "./create-branded-string-schema.js";
 /**
  * A Zod schema for Solana addresses.
  * Validates that a string is a valid Solana address and transforms it to an Address type.
- * Compatible with both Zod v3 and v4.
  */
 export const addressSchema: z.ZodType<Address, string> =
   createBrandedStringSchema(address, "Invalid Solana address");

--- a/packages/zod-solana/src/blockhash-schema.test.ts
+++ b/packages/zod-solana/src/blockhash-schema.test.ts
@@ -1,0 +1,69 @@
+import type * as z from "zod";
+import { describe, expect, it } from "bun:test";
+import { blockhash } from "@solana/kit";
+import { blockhashSchema } from "./blockhash-schema.js";
+
+const VALID_BLOCKHASH = "8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR";
+
+describe("blockhashSchema", () => {
+  it("should validate and transform a valid blockhash", () => {
+    const result = blockhashSchema.parse(VALID_BLOCKHASH);
+
+    expect(result).toBe(blockhash(VALID_BLOCKHASH));
+  });
+
+  it("should accept the all-zero blockhash", () => {
+    const zeroBlockhash = "1".repeat(32);
+    const result = blockhashSchema.parse(zeroBlockhash);
+
+    expect(result).toBe(blockhash(zeroBlockhash));
+  });
+
+  it("should reject empty strings", () => {
+    expect(() => blockhashSchema.parse("")).toThrow();
+  });
+
+  it("should reject blockhashes with invalid characters", () => {
+    expect(() => blockhashSchema.parse(`0OIl+/${"1".repeat(38)}`)).toThrow();
+  });
+
+  it("should reject blockhashes that are too short", () => {
+    expect(() => blockhashSchema.parse("abc")).toThrow();
+  });
+
+  it("should reject a 64-byte value such as a signature", () => {
+    expect(() =>
+      blockhashSchema.parse(
+        "2AXDGYSE4f2sz7tvMMzyHvUfcoJmxudvdhBcmiUSo6ijwfYmfZYsKRxboQMPh3R4kUhXRVdtSXFXMheka4Rc4P2",
+      ),
+    ).toThrow();
+  });
+
+  it("should provide a helpful error message for invalid blockhashes", () => {
+    const result = blockhashSchema.safeParse("not-a-valid-blockhash");
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe("Invalid Solana blockhash");
+    }
+  });
+
+  it("should work with safeParse", () => {
+    const validResult = blockhashSchema.safeParse(VALID_BLOCKHASH);
+    expect(validResult.success).toBe(true);
+    if (validResult.success) {
+      expect(validResult.data).toBe(blockhash(VALID_BLOCKHASH));
+    }
+
+    const invalidResult = blockhashSchema.safeParse("invalid");
+    expect(invalidResult.success).toBe(false);
+  });
+
+  it("should infer the correct TypeScript type", () => {
+    // This is a compile-time test
+    type InferredType = z.output<typeof blockhashSchema>;
+    const testBlockhash: InferredType = blockhash(VALID_BLOCKHASH);
+
+    expect(testBlockhash).toBeDefined();
+  });
+});

--- a/packages/zod-solana/src/blockhash-schema.ts
+++ b/packages/zod-solana/src/blockhash-schema.ts
@@ -1,6 +1,7 @@
 import type { Blockhash } from "@solana/kit";
+import type * as z from "zod";
 import { blockhash } from "@solana/kit";
-import * as z from "zod";
+import { createBrandedStringSchema } from "./create-branded-string-schema.js";
 
 /**
  * A Zod schema for Solana blockhashes.
@@ -8,16 +9,5 @@ import * as z from "zod";
  * transforms it to a Blockhash type.
  * Compatible with both Zod v3 and v4.
  */
-export const blockhashSchema: z.ZodType<Blockhash, string> = z
-  .string()
-  .transform((val, ctx) => {
-    try {
-      return blockhash(val);
-    } catch {
-      ctx.addIssue({
-        code: "custom",
-        message: "Invalid Solana blockhash",
-      });
-      return z.NEVER;
-    }
-  });
+export const blockhashSchema: z.ZodType<Blockhash, string> =
+  createBrandedStringSchema(blockhash, "Invalid Solana blockhash");

--- a/packages/zod-solana/src/blockhash-schema.ts
+++ b/packages/zod-solana/src/blockhash-schema.ts
@@ -1,0 +1,23 @@
+import type { Blockhash } from "@solana/kit";
+import { blockhash } from "@solana/kit";
+import * as z from "zod";
+
+/**
+ * A Zod schema for Solana blockhashes.
+ * Validates that a string is a valid base58-encoded 32-byte blockhash and
+ * transforms it to a Blockhash type.
+ * Compatible with both Zod v3 and v4.
+ */
+export const blockhashSchema: z.ZodType<Blockhash, string> = z
+  .string()
+  .transform((val, ctx) => {
+    try {
+      return blockhash(val);
+    } catch {
+      ctx.addIssue({
+        code: "custom",
+        message: "Invalid Solana blockhash",
+      });
+      return z.NEVER;
+    }
+  });

--- a/packages/zod-solana/src/blockhash-schema.ts
+++ b/packages/zod-solana/src/blockhash-schema.ts
@@ -7,7 +7,6 @@ import { createBrandedStringSchema } from "./create-branded-string-schema.js";
  * A Zod schema for Solana blockhashes.
  * Validates that a string is a valid base58-encoded 32-byte blockhash and
  * transforms it to a Blockhash type.
- * Compatible with both Zod v3 and v4.
  */
 export const blockhashSchema: z.ZodType<Blockhash, string> =
   createBrandedStringSchema(blockhash, "Invalid Solana blockhash");

--- a/packages/zod-solana/src/create-branded-string-schema.ts
+++ b/packages/zod-solana/src/create-branded-string-schema.ts
@@ -1,0 +1,28 @@
+import * as z from "zod";
+
+/**
+ * Builds a Zod schema around one of @solana/kit's branded-string constructors.
+ *
+ * The constructor validates its input and throws on anything malformed, so the
+ * schema catches that and reports `message` as a custom issue. Returning
+ * `z.NEVER` on failure keeps the schema compatible with both Zod v3 and v4.
+ *
+ * Internal helper -- shared by the address, signature, and blockhash schemas,
+ * each of which stays in its own module so consumers only pull in the ones they
+ * actually use.
+ */
+export const createBrandedStringSchema = <T extends string>(
+  toBranded: (value: string) => T,
+  message: string,
+): z.ZodType<T, string> =>
+  z.string().transform((val, ctx) => {
+    try {
+      return toBranded(val);
+    } catch {
+      ctx.addIssue({
+        code: "custom",
+        message,
+      });
+      return z.NEVER;
+    }
+  });

--- a/packages/zod-solana/src/create-branded-string-schema.ts
+++ b/packages/zod-solana/src/create-branded-string-schema.ts
@@ -4,8 +4,8 @@ import * as z from "zod";
  * Builds a Zod schema around one of @solana/kit's branded-string constructors.
  *
  * The constructor validates its input and throws on anything malformed, so the
- * schema catches that and reports `message` as a custom issue. Returning
- * `z.NEVER` on failure keeps the schema compatible with both Zod v3 and v4.
+ * schema catches that and reports `message` as a custom issue, returning
+ * `z.NEVER` to abort the transform.
  *
  * Internal helper -- shared by the address, signature, and blockhash schemas,
  * each of which stays in its own module so consumers only pull in the ones they

--- a/packages/zod-solana/src/index.ts
+++ b/packages/zod-solana/src/index.ts
@@ -1,4 +1,5 @@
 export { addressSchema } from "./address-schema.js";
+export { blockhashSchema } from "./blockhash-schema.js";
 export { bpsSchema } from "./bps-schema.js";
 export { U8_MAX, U16_MAX, U32_MAX, U64_MAX } from "./constants.js";
 export {
@@ -10,6 +11,7 @@ export {
   type TokenMetadataProperties,
   tokenMetadataSchema,
 } from "./token-metadata-schema.js";
+export { signatureSchema } from "./signature-schema.js";
 export { u8Schema } from "./u8-schema.js";
 export { u16Schema } from "./u16-schema.js";
 export { u32Schema } from "./u32-schema.js";

--- a/packages/zod-solana/src/signature-schema.test.ts
+++ b/packages/zod-solana/src/signature-schema.test.ts
@@ -1,0 +1,72 @@
+import type * as z from "zod";
+import { describe, expect, it } from "bun:test";
+import { signature } from "@solana/kit";
+import { signatureSchema } from "./signature-schema.js";
+
+const VALID_SIGNATURE =
+  "2AXDGYSE4f2sz7tvMMzyHvUfcoJmxudvdhBcmiUSo6ijwfYmfZYsKRxboQMPh3R4kUhXRVdtSXFXMheka4Rc4P2";
+
+describe("signatureSchema", () => {
+  it("should validate and transform a valid signature", () => {
+    const result = signatureSchema.parse(VALID_SIGNATURE);
+
+    expect(result).toBe(signature(VALID_SIGNATURE));
+  });
+
+  it("should accept the all-zero signature", () => {
+    const zeroSignature = "1".repeat(64);
+    const result = signatureSchema.parse(zeroSignature);
+
+    expect(result).toBe(signature(zeroSignature));
+  });
+
+  it("should reject empty strings", () => {
+    expect(() => signatureSchema.parse("")).toThrow();
+  });
+
+  it("should reject signatures with invalid characters", () => {
+    expect(() => signatureSchema.parse(`0OIl+/${"1".repeat(82)}`)).toThrow();
+  });
+
+  it("should reject signatures that are too short", () => {
+    expect(() => signatureSchema.parse("abc")).toThrow();
+  });
+
+  it("should reject signatures that are too long", () => {
+    expect(() => signatureSchema.parse("1".repeat(96))).toThrow();
+  });
+
+  it("should reject a 32-byte value such as an address", () => {
+    expect(() =>
+      signatureSchema.parse("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"),
+    ).toThrow();
+  });
+
+  it("should provide a helpful error message for invalid signatures", () => {
+    const result = signatureSchema.safeParse("not-a-valid-signature");
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe("Invalid Solana signature");
+    }
+  });
+
+  it("should work with safeParse", () => {
+    const validResult = signatureSchema.safeParse(VALID_SIGNATURE);
+    expect(validResult.success).toBe(true);
+    if (validResult.success) {
+      expect(validResult.data).toBe(signature(VALID_SIGNATURE));
+    }
+
+    const invalidResult = signatureSchema.safeParse("invalid");
+    expect(invalidResult.success).toBe(false);
+  });
+
+  it("should infer the correct TypeScript type", () => {
+    // This is a compile-time test
+    type InferredType = z.output<typeof signatureSchema>;
+    const testSignature: InferredType = signature(VALID_SIGNATURE);
+
+    expect(testSignature).toBeDefined();
+  });
+});

--- a/packages/zod-solana/src/signature-schema.ts
+++ b/packages/zod-solana/src/signature-schema.ts
@@ -1,0 +1,23 @@
+import type { Signature } from "@solana/kit";
+import { signature } from "@solana/kit";
+import * as z from "zod";
+
+/**
+ * A Zod schema for Solana transaction signatures.
+ * Validates that a string is a valid base58-encoded 64-byte signature and
+ * transforms it to a Signature type.
+ * Compatible with both Zod v3 and v4.
+ */
+export const signatureSchema: z.ZodType<Signature, string> = z
+  .string()
+  .transform((val, ctx) => {
+    try {
+      return signature(val);
+    } catch {
+      ctx.addIssue({
+        code: "custom",
+        message: "Invalid Solana signature",
+      });
+      return z.NEVER;
+    }
+  });

--- a/packages/zod-solana/src/signature-schema.ts
+++ b/packages/zod-solana/src/signature-schema.ts
@@ -7,7 +7,6 @@ import { createBrandedStringSchema } from "./create-branded-string-schema.js";
  * A Zod schema for Solana transaction signatures.
  * Validates that a string is a valid base58-encoded 64-byte signature and
  * transforms it to a Signature type.
- * Compatible with both Zod v3 and v4.
  */
 export const signatureSchema: z.ZodType<Signature, string> =
   createBrandedStringSchema(signature, "Invalid Solana signature");

--- a/packages/zod-solana/src/signature-schema.ts
+++ b/packages/zod-solana/src/signature-schema.ts
@@ -1,6 +1,7 @@
 import type { Signature } from "@solana/kit";
+import type * as z from "zod";
 import { signature } from "@solana/kit";
-import * as z from "zod";
+import { createBrandedStringSchema } from "./create-branded-string-schema.js";
 
 /**
  * A Zod schema for Solana transaction signatures.
@@ -8,16 +9,5 @@ import * as z from "zod";
  * transforms it to a Signature type.
  * Compatible with both Zod v3 and v4.
  */
-export const signatureSchema: z.ZodType<Signature, string> = z
-  .string()
-  .transform((val, ctx) => {
-    try {
-      return signature(val);
-    } catch {
-      ctx.addIssue({
-        code: "custom",
-        message: "Invalid Solana signature",
-      });
-      return z.NEVER;
-    }
-  });
+export const signatureSchema: z.ZodType<Signature, string> =
+  createBrandedStringSchema(signature, "Invalid Solana signature");


### PR DESCRIPTION
Adds two new schemas to `@macalinao/zod-solana`:

- **`signatureSchema`** — parses a string into a `Signature` (base58, 64 bytes) via `signature()` from `@solana/kit`. Invalid input yields `"Invalid Solana signature"`.
- **`blockhashSchema`** — parses a string into a `Blockhash` (base58, 32 bytes) via `blockhash()` from `@solana/kit`. Invalid input yields `"Invalid Solana blockhash"`.

Each schema lives in its own file (`signature-schema.ts`, `blockhash-schema.ts`) and is re-exported from `index.ts`, matching the existing one-schema-per-file layout so bundlers can tree-shake unused schemas.

Also includes tests for both (valid/invalid, length mismatches, base58 charset, `safeParse`, type inference), README API entries, and a minor changeset.

## Test plan

- `bun run build` — passes
- `bun run lint:fix` — clean
- `bun test` in `packages/zod-solana` — 253 pass, 0 fail

## Summary by Sourcery

Add new Zod schemas for validating and transforming Solana transaction signatures and blockhashes, and expose them from the zod-solana package.

New Features:
- Introduce signatureSchema for validating base58-encoded 64-byte Solana transaction signatures and transforming them into the Signature type from @solana/kit.
- Introduce blockhashSchema for validating base58-encoded 32-byte Solana blockhashes and transforming them into the Blockhash type from @solana/kit.

Documentation:
- Document signatureSchema and blockhashSchema in the zod-solana README with usage and error behavior.

Tests:
- Add unit tests for signatureSchema and blockhashSchema covering valid/invalid inputs, length and character checks, safeParse behavior, and TypeScript type inference.

Chores:
- Add a minor changeset entry to publish the new signatureSchema and blockhashSchema APIs in @macalinao/zod-solana.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation schemas for Solana signatures and blockhashes.
  * Valid values are transformed into strongly typed Solana values.
  * Schemas support both Zod v3 and Zod v4.

* **Documentation**
  * Added API documentation and usage details for the new schemas.

* **Bug Fixes**
  * Improved consistent validation and error reporting for Solana addresses and branded string values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->