### PR TITLE
feat: configurable console log level

### DIFF
--- a/.changeset/configurable-log-level.md
+++ b/.changeset/configurable-log-level.md
@@ -1,6 +1,7 @@
 ---
 "@macalinao/grill": minor
 "@macalinao/gill-extra": minor
+"@macalinao/wallet-adapter-compat": patch
 ---
 
 Make console logging configurable so apps built on grill can control (or silence) the library's output.
@@ -8,6 +9,7 @@ Make console logging configurable so apps built on grill can control (or silence
 - `GrillProvider` and `GrillHeadlessProvider` accept a `logLevel` prop: `"off" | "error" | "warn" | "info" | "debug"`, defaulting to `"info"`. Each level enables itself and everything more severe; `"off"` emits no console output at all.
 - Every `console.*` call in grill now goes through that level — failed transactions and simulations at `"error"`, background refetch failures at `"warn"`, and the per-event transaction status dump (previously an unconditional `console.log` for anyone without an `onTransactionStatusEvent` handler) at `"debug"`.
 - New `useLogger()` hook returns the configured logger, so app-level logging can be silenced by the same prop.
+- `@macalinao/wallet-adapter-compat` no longer logs every transaction's base64 wire bytes to the console — that was a leftover debug statement, now removed.
 - `@macalinao/gill-extra` exports `createLogger`, `defaultLogger`, `DEFAULT_LOG_LEVEL` and the `LogLevel` / `Logger` types. `logTransactionSimulation`, `fetchTokenInfo`, `fetchTokenInfoForMint` and `pollConfirmTransaction` take an optional `logger`; they keep logging at the default level when none is passed.
 
 Since the default level is `"info"`, existing apps mostly see the same output minus the transaction status firehose. Pass `logLevel="error"` (or `"off"`) to quiet things down in production.

--- a/.changeset/configurable-log-level.md
+++ b/.changeset/configurable-log-level.md
@@ -1,0 +1,13 @@
+---
+"@macalinao/grill": minor
+"@macalinao/gill-extra": minor
+---
+
+Make console logging configurable so apps built on grill can control (or silence) the library's output.
+
+- `GrillProvider` and `GrillHeadlessProvider` accept a `logLevel` prop: `"off" | "error" | "warn" | "info" | "debug"`, defaulting to `"info"`. Each level enables itself and everything more severe; `"off"` emits no console output at all.
+- Every `console.*` call in grill now goes through that level — failed transactions and simulations at `"error"`, background refetch failures at `"warn"`, and the per-event transaction status dump (previously an unconditional `console.log` for anyone without an `onTransactionStatusEvent` handler) at `"debug"`.
+- New `useLogger()` hook returns the configured logger, so app-level logging can be silenced by the same prop.
+- `@macalinao/gill-extra` exports `createLogger`, `defaultLogger`, `DEFAULT_LOG_LEVEL` and the `LogLevel` / `Logger` types. `logTransactionSimulation`, `fetchTokenInfo`, `fetchTokenInfoForMint` and `pollConfirmTransaction` take an optional `logger`; they keep logging at the default level when none is passed.
+
+Since the default level is `"info"`, existing apps mostly see the same output minus the transaction status firehose. Pass `logLevel="error"` (or `"off"`) to quiet things down in production.

--- a/apps/example-dapp/src/App.tsx
+++ b/apps/example-dapp/src/App.tsx
@@ -81,6 +81,9 @@ export const App: React.FC = () => {
                   <GrillProvider
                     getExplorerLink={getSolscanExplorerLink}
                     staticTokenInfo={STATIC_TOKEN_INFO}
+                    // Verbose while developing; production builds only get the
+                    // failures. Use "off" to silence the library entirely.
+                    logLevel={import.meta.env.DEV ? "debug" : "warn"}
                   >
                     <div className="min-h-screen bg-background">
                       <RouterProvider router={router} />

--- a/apps/example-dapp/src/routes/examples/wrapped-sol.tsx
+++ b/apps/example-dapp/src/routes/examples/wrapped-sol.tsx
@@ -7,6 +7,7 @@ import {
   useAccount,
   useAssociatedTokenAccount,
   useKitWallet,
+  useLogger,
   useSendTX,
 } from "@macalinao/grill";
 import { createFileRoute } from "@tanstack/react-router";
@@ -32,6 +33,9 @@ import {
 const WrappedSOLPage: React.FC = () => {
   const { signer } = useKitWallet();
   const sendTX = useSendTX();
+  // App logging routed through the provider's `logLevel`, so it goes quiet
+  // along with grill's own output.
+  const logger = useLogger();
   const { data: userAccount } = useAccount({
     address: signer ? signer.address : null,
   });
@@ -104,11 +108,11 @@ const WrappedSOLPage: React.FC = () => {
         transaction: signature,
         cluster: "mainnet",
       });
-      console.log("Transaction:", explorerLink);
+      logger.info("Transaction:", explorerLink);
 
       setWrapAmount("");
     } catch (error) {
-      console.error("Error wrapping SOL:", error);
+      logger.error("Error wrapping SOL:", error);
       // Error already handled by mutation
     } finally {
       setIsWrapping(false);
@@ -134,9 +138,9 @@ const WrappedSOLPage: React.FC = () => {
         transaction: signature,
         cluster: "mainnet",
       });
-      console.log("Transaction:", explorerLink);
+      logger.info("Transaction:", explorerLink);
     } catch (error) {
-      console.error("Error closing wSOL account:", error);
+      logger.error("Error closing wSOL account:", error);
       // Error already handled by mutation
     } finally {
       setIsClosing(false);

--- a/docs/grill/02-setup.md
+++ b/docs/grill/02-setup.md
@@ -251,6 +251,8 @@ const SwapButton: React.FC = () => {
   showToasts={true} // Enable toast notifications (default: true)
   successToastDuration={5000} // Success toast duration (default: 5000ms)
   errorToastDuration={7000} // Error toast duration (default: 7000ms)
+  // Console verbosity: "off" | "error" | "warn" | "info" | "debug"
+  logLevel="info" // (default: "info")
   // Custom transaction status handler
   onTransactionStatusEvent={(event) => {
     console.log("Transaction status:", event);
@@ -260,6 +262,40 @@ const SwapButton: React.FC = () => {
   {children}
 </GrillProvider>
 ```
+
+### Console Logging
+
+Grill writes diagnostics to the console — failed simulations, dropped
+subscriptions, transaction logs. `logLevel` decides how much of it your users
+see. Each level enables itself and everything more severe, and `"off"` silences
+the library completely:
+
+```tsx
+<GrillProvider logLevel={import.meta.env.DEV ? "debug" : "error"}>
+  {children}
+</GrillProvider>
+```
+
+`useLogger()` returns the same level-aware logger for your own code:
+
+```tsx
+import { useLogger } from "@macalinao/grill";
+
+const SwapButton: React.FC = () => {
+  const logger = useLogger();
+
+  const onSwap = async () => {
+    logger.debug("submitting swap");
+    // ...
+  };
+
+  return <button onClick={onSwap}>Swap</button>;
+};
+```
+
+Outside React, the plain functions in `@macalinao/gill-extra` that log
+(`logTransactionSimulation`, `fetchTokenInfo`, `pollConfirmTransaction`) take an
+optional `logger`, so `createLogger("off")` silences those too.
 
 ### Headless Mode
 

--- a/packages/gill-extra/src/fetch-token-info-for-mint.ts
+++ b/packages/gill-extra/src/fetch-token-info-for-mint.ts
@@ -38,6 +38,7 @@ export async function fetchTokenInfoForMint({
   mint,
   fetchFromCertifiedTokenList,
   validateMetadata,
+  logger,
 }: FetchTokenInfoForMintParams): Promise<TokenInfo> {
   // Find the metadata PDA
   const [metadataPda] = await findMetadataPda({
@@ -73,5 +74,6 @@ export async function fetchTokenInfoForMint({
     metadata,
     fetchFromCertifiedTokenList,
     validateMetadata,
+    logger,
   });
 }

--- a/packages/gill-extra/src/fetch-token-info.ts
+++ b/packages/gill-extra/src/fetch-token-info.ts
@@ -1,9 +1,11 @@
 import type { Metadata } from "@macalinao/clients-token-metadata";
 import type { TokenInfo } from "@macalinao/token-utils";
 import type { Mint } from "@solana-program/token";
+import type { Logger } from "./logger.js";
 import type { TokenMetadataValidator } from "./token-metadata-validator.js";
 import type { AccountInfo } from "./types.js";
 import { createTokenInfo } from "@macalinao/token-utils";
+import { defaultLogger } from "./logger.js";
 import { defaultTokenMetadataValidator } from "./token-metadata-validator.js";
 
 export interface FetchTokenInfoParams {
@@ -22,6 +24,10 @@ export interface FetchTokenInfoParams {
    * `@macalinao/zod-solana` to validate the full Metaplex schema instead.
    */
   validateMetadata?: TokenMetadataValidator | undefined;
+  /**
+   * Logger used for metadata fetch failures. Defaults to {@link defaultLogger}.
+   */
+  logger?: Logger | undefined;
 }
 
 /**
@@ -34,6 +40,7 @@ export async function fetchTokenInfo({
   metadata,
   fetchFromCertifiedTokenList = true,
   validateMetadata = defaultTokenMetadataValidator,
+  logger = defaultLogger,
 }: FetchTokenInfoParams): Promise<TokenInfo> {
   const uri = metadata?.data.uri;
   const decimals = mint.data.decimals;
@@ -73,12 +80,12 @@ export async function fetchTokenInfo({
               metadataUriJson = { image: parsed.image };
             }
           } else {
-            console.error("Invalid token metadata at URI:", uri);
+            logger.error("Invalid token metadata at URI:", uri);
           }
         }
       }
     } catch (error) {
-      console.error("Error fetching token info:", error);
+      logger.error("Error fetching token info:", error);
     }
   }
 
@@ -110,7 +117,7 @@ export async function fetchTokenInfo({
         tokenInfo.iconURL = data.logoURI;
       }
     } catch (error) {
-      console.warn("Could not fetch certified token info:", error);
+      logger.warn("Could not fetch certified token info:", error);
     }
   }
 

--- a/packages/gill-extra/src/index.ts
+++ b/packages/gill-extra/src/index.ts
@@ -13,6 +13,7 @@ export * from "./get-signature-from-bytes.js";
 export * from "./get-solscan-explorer-link.js";
 export * from "./ixs/index.js";
 export * from "./log-transaction-simulation.js";
+export * from "./logger.js";
 export * from "./poll-confirm-transaction.js";
 export * from "./token-metadata-validator.js";
 export * from "./transaction.js";

--- a/packages/gill-extra/src/log-transaction-simulation.test.ts
+++ b/packages/gill-extra/src/log-transaction-simulation.test.ts
@@ -1,8 +1,20 @@
-import { describe, expect, it } from "bun:test";
+import type { Blockhash } from "@solana/kit";
+import type { Mock } from "bun:test";
+import type { SimulationResultValue } from "./log-transaction-simulation.js";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import {
+  address,
+  createTransactionMessage,
+  pipe,
+  setTransactionMessageFeePayer,
+  setTransactionMessageLifetimeUsingBlockhash,
+} from "@solana/kit";
 import {
   createSimulationDebugBlock,
   formatSimulationLog,
+  logTransactionSimulation,
 } from "./log-transaction-simulation.js";
+import { createLogger } from "./logger.js";
 
 describe("formatSimulationLog", () => {
   it("should format error logs with red color", () => {
@@ -83,5 +95,128 @@ describe("createSimulationDebugBlock", () => {
     expect(result).toContain("Transaction: Transfer");
     expect(result).toContain("Error: Unknown error");
     expect(result).toContain("Logs:");
+  });
+});
+
+describe("logTransactionSimulation log levels", () => {
+  const CONSOLE_METHODS = [
+    "log",
+    "error",
+    "warn",
+    "debug",
+    "group",
+    "groupCollapsed",
+    "groupEnd",
+  ] as const;
+
+  type ConsoleMethod = (typeof CONSOLE_METHODS)[number];
+
+  let spies: Record<ConsoleMethod, Mock<(...args: unknown[]) => void>>;
+
+  beforeEach(() => {
+    spies = Object.fromEntries(
+      CONSOLE_METHODS.map((method) => [
+        method,
+        spyOn(console, method).mockImplementation(() => {
+          // Swallow the output; the tests only care that it was attempted.
+        }),
+      ]),
+    ) as Record<ConsoleMethod, Mock<(...args: unknown[]) => void>>;
+  });
+
+  afterEach(() => {
+    for (const method of CONSOLE_METHODS) {
+      spies[method].mockRestore();
+    }
+  });
+
+  const totalCalls = (): number =>
+    CONSOLE_METHODS.reduce(
+      (sum, method) => sum + spies[method].mock.calls.length,
+      0,
+    );
+
+  const transactionMessage = pipe(
+    createTransactionMessage({ version: 0 }),
+    (message) =>
+      setTransactionMessageFeePayer(
+        address("SysvarC1ock11111111111111111111111111111111"),
+        message,
+      ),
+    (message) =>
+      setTransactionMessageLifetimeUsingBlockhash(
+        {
+          blockhash: "11111111111111111111111111111111" as Blockhash,
+          lastValidBlockHeight: 100n,
+        },
+        message,
+      ),
+  );
+
+  const FAILED: SimulationResultValue = {
+    err: "AccountNotFound",
+    logs: ["Program invoked", "Program log: boom"],
+  };
+
+  const SUCCEEDED: SimulationResultValue = {
+    err: null,
+    logs: ["Program invoked"],
+  };
+
+  it("emits nothing when the logger is off", () => {
+    for (const simulationResult of [FAILED, SUCCEEDED]) {
+      logTransactionSimulation({
+        title: "Swap",
+        simulationResult,
+        transactionMessage,
+        logger: createLogger("off"),
+      });
+    }
+
+    expect(totalCalls()).toBe(0);
+  });
+
+  it("reports a failed simulation at the error level", () => {
+    logTransactionSimulation({
+      title: "Swap",
+      simulationResult: FAILED,
+      transactionMessage,
+      logger: createLogger("error"),
+    });
+
+    expect(spies.group).toHaveBeenCalled();
+    expect(spies.error).toHaveBeenCalled();
+    expect(spies.log).not.toHaveBeenCalled();
+  });
+
+  it("reports a successful simulation at the info level", () => {
+    logTransactionSimulation({
+      title: "Swap",
+      simulationResult: SUCCEEDED,
+      transactionMessage,
+      logger: createLogger("error"),
+    });
+
+    expect(totalCalls()).toBe(0);
+
+    logTransactionSimulation({
+      title: "Swap",
+      simulationResult: SUCCEEDED,
+      transactionMessage,
+      logger: createLogger("info"),
+    });
+
+    expect(spies.log).toHaveBeenCalled();
+  });
+
+  it("uses the default logger, which is info, when none is given", () => {
+    logTransactionSimulation({
+      title: "Swap",
+      simulationResult: SUCCEEDED,
+      transactionMessage,
+    });
+
+    expect(spies.log).toHaveBeenCalled();
+    expect(spies.debug).not.toHaveBeenCalled();
   });
 });

--- a/packages/gill-extra/src/log-transaction-simulation.ts
+++ b/packages/gill-extra/src/log-transaction-simulation.ts
@@ -3,7 +3,9 @@ import type {
   TransactionMessage,
   TransactionMessageWithFeePayer,
 } from "@solana/kit";
+import type { LogLevel, Logger } from "./logger.js";
 import type { SolanaCluster } from "./transaction.js";
+import { defaultLogger } from "./logger.js";
 import { parseTransactionError } from "./transaction-error.js";
 import { createTransactionInspectorUrlWithOptions } from "./transaction.js";
 
@@ -45,6 +47,13 @@ export interface LogTransactionSimulationOptions {
    * Required when using localhost or custom RPC endpoints.
    */
   rpcUrl?: string | undefined;
+  /**
+   * Logger used for the output. Defaults to {@link defaultLogger}.
+   *
+   * Pass the logger configured on `GrillProvider` to have this respect the
+   * app's `logLevel`.
+   */
+  logger?: Logger | undefined;
 }
 
 /**
@@ -106,6 +115,9 @@ export function createSimulationDebugBlock(options: {
  * - Collapsible simulation logs (color-coded)
  * - Inspector URL for the Solana Explorer
  * - Copy-paste friendly debugging block
+ *
+ * A failed simulation is reported at the `"error"` level and a successful one
+ * at `"info"`, so a logger configured below that level prints nothing.
  */
 export function logTransactionSimulation(
   options: LogTransactionSimulationOptions,
@@ -116,10 +128,17 @@ export function logTransactionSimulation(
     transactionMessage,
     cluster = "mainnet-beta",
     rpcUrl,
+    logger = defaultLogger,
   } = options;
 
-  const logs = [...(simulationResult.logs ?? [])];
   const success = simulationResult.err === null;
+  const level: LogLevel = success ? "info" : "error";
+  // Bail before building the inspector URL, which is not free.
+  if (!logger.isEnabled(level)) {
+    return;
+  }
+
+  const logs = [...(simulationResult.logs ?? [])];
   const errorMessage =
     success || simulationResult.err === null
       ? undefined
@@ -136,18 +155,21 @@ export function logTransactionSimulation(
 
   if (success) {
     // Log success with green styling
-    console.group(
+    logger.group(
+      level,
       `%c✅ Transaction Simulation Succeeded: ${title}`,
       "color: #69db7c; font-weight: bold; font-size: 14px;",
     );
   } else {
     // Log failure with red styling
-    console.group(
+    logger.group(
+      level,
       `%c🚫 Transaction Simulation Failed: ${title}`,
       "color: #ff6b6b; font-weight: bold; font-size: 14px;",
     );
     if (errorMessage) {
-      console.log(
+      logger.log(
+        level,
         "%cError:",
         "color: #ff6b6b; font-weight: bold;",
         errorMessage,
@@ -156,29 +178,36 @@ export function logTransactionSimulation(
   }
 
   if (logs.length > 0) {
-    console.groupCollapsed(
+    logger.groupCollapsed(
+      level,
       "%c📋 Simulation Logs",
       "color: #ffa94d; font-weight: bold;",
     );
     for (const log of logs) {
       const formatted = formatSimulationLog(log);
       if (formatted.style) {
-        console.log(formatted.text, formatted.style);
+        logger.log(level, formatted.text, formatted.style);
       } else {
-        console.log(formatted.text);
+        logger.log(level, formatted.text);
       }
     }
-    console.groupEnd();
+    logger.groupEnd(level);
   }
 
-  console.log(
+  logger.log(
+    level,
     "%c🔍 Inspect Transaction:",
     "color: #74c0fc; font-weight: bold;",
   );
-  console.log(inspectorUrl);
+  logger.log(level, inspectorUrl);
 
-  console.log("%c📋 Copy for debugging:", "color: #b197fc; font-weight: bold;");
-  console.log(
+  logger.log(
+    level,
+    "%c📋 Copy for debugging:",
+    "color: #b197fc; font-weight: bold;",
+  );
+  logger.log(
+    level,
     createSimulationDebugBlock({
       title,
       success,
@@ -188,5 +217,5 @@ export function logTransactionSimulation(
     }),
   );
 
-  console.groupEnd();
+  logger.groupEnd(level);
 }

--- a/packages/gill-extra/src/logger.test.ts
+++ b/packages/gill-extra/src/logger.test.ts
@@ -1,0 +1,188 @@
+import type { Mock } from "bun:test";
+import type { LogLevel } from "./logger.js";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { createLogger, DEFAULT_LOG_LEVEL, defaultLogger } from "./logger.js";
+
+/** Every console method the logger is allowed to reach for. */
+const CONSOLE_METHODS = [
+  "log",
+  "error",
+  "warn",
+  "debug",
+  "group",
+  "groupCollapsed",
+  "groupEnd",
+] as const;
+
+type ConsoleMethod = (typeof CONSOLE_METHODS)[number];
+
+type ConsoleSpies = Record<ConsoleMethod, Mock<(...args: unknown[]) => void>>;
+
+let spies: ConsoleSpies;
+
+beforeEach(() => {
+  spies = Object.fromEntries(
+    CONSOLE_METHODS.map((method) => [
+      method,
+      spyOn(console, method).mockImplementation(() => {
+        // Swallow the output; the tests only care that it was attempted.
+      }),
+    ]),
+  ) as ConsoleSpies;
+});
+
+afterEach(() => {
+  for (const method of CONSOLE_METHODS) {
+    spies[method].mockRestore();
+  }
+});
+
+/** Total number of console calls across every method. */
+function totalCalls(): number {
+  return CONSOLE_METHODS.reduce(
+    (sum, method) => sum + spies[method].mock.calls.length,
+    0,
+  );
+}
+
+/** Exercises every logger entry point at every level. */
+function logEverything(level: LogLevel): void {
+  const logger = createLogger(level);
+  logger.error("error");
+  logger.warn("warn");
+  logger.info("info");
+  logger.debug("debug");
+  for (const messageLevel of [
+    "off",
+    "error",
+    "warn",
+    "info",
+    "debug",
+  ] as const) {
+    logger.log(messageLevel, "log");
+    logger.group(messageLevel, "group");
+    logger.groupCollapsed(messageLevel, "groupCollapsed");
+    logger.groupEnd(messageLevel);
+  }
+}
+
+describe("createLogger", () => {
+  it("defaults to the info level", () => {
+    expect(DEFAULT_LOG_LEVEL).toBe("info");
+    expect(createLogger().level).toBe("info");
+    expect(defaultLogger.level).toBe("info");
+  });
+
+  it("emits errors, warnings and info at the default level, but not debug", () => {
+    const logger = createLogger();
+
+    logger.error("boom");
+    logger.warn("careful");
+    logger.info("fyi");
+    logger.debug("noisy");
+
+    expect(spies.error).toHaveBeenCalledWith("boom");
+    expect(spies.warn).toHaveBeenCalledWith("careful");
+    expect(spies.log).toHaveBeenCalledWith("fyi");
+    expect(spies.debug).not.toHaveBeenCalled();
+  });
+
+  it("emits nothing at all when off", () => {
+    logEverything("off");
+
+    expect(totalCalls()).toBe(0);
+  });
+
+  it("emits only errors at the error level", () => {
+    const logger = createLogger("error");
+
+    logger.error("boom");
+    logger.warn("careful");
+    logger.info("fyi");
+    logger.debug("noisy");
+
+    expect(spies.error).toHaveBeenCalledTimes(1);
+    expect(spies.warn).not.toHaveBeenCalled();
+    expect(spies.log).not.toHaveBeenCalled();
+    expect(spies.debug).not.toHaveBeenCalled();
+  });
+
+  it("emits errors and warnings at the warn level", () => {
+    const logger = createLogger("warn");
+
+    logger.error("boom");
+    logger.warn("careful");
+    logger.info("fyi");
+    logger.debug("noisy");
+
+    expect(spies.error).toHaveBeenCalledTimes(1);
+    expect(spies.warn).toHaveBeenCalledTimes(1);
+    expect(spies.log).not.toHaveBeenCalled();
+    expect(spies.debug).not.toHaveBeenCalled();
+  });
+
+  it("emits everything at the debug level", () => {
+    const logger = createLogger("debug");
+
+    logger.error("boom");
+    logger.warn("careful");
+    logger.info("fyi");
+    logger.debug("noisy");
+
+    expect(spies.error).toHaveBeenCalledTimes(1);
+    expect(spies.warn).toHaveBeenCalledTimes(1);
+    expect(spies.log).toHaveBeenCalledTimes(1);
+    expect(spies.debug).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes every argument through", () => {
+    const logger = createLogger("debug");
+    const details = { attempt: 2 };
+
+    logger.warn("retrying:", details);
+
+    expect(spies.warn).toHaveBeenCalledWith("retrying:", details);
+  });
+
+  it("reports which levels are enabled", () => {
+    const logger = createLogger("warn");
+
+    expect(logger.isEnabled("error")).toBe(true);
+    expect(logger.isEnabled("warn")).toBe(true);
+    expect(logger.isEnabled("info")).toBe(false);
+    expect(logger.isEnabled("debug")).toBe(false);
+    // `off` is never a level a message is emitted at.
+    expect(logger.isEnabled("off")).toBe(false);
+    expect(createLogger("debug").isEnabled("off")).toBe(false);
+  });
+
+  it("only opens and closes groups whose level is enabled", () => {
+    const logger = createLogger("warn");
+
+    logger.group("warn", "shown");
+    logger.groupEnd("warn");
+    logger.groupCollapsed("info", "hidden");
+    logger.groupEnd("info");
+
+    expect(spies.group).toHaveBeenCalledTimes(1);
+    expect(spies.group).toHaveBeenCalledWith("shown");
+    expect(spies.groupCollapsed).not.toHaveBeenCalled();
+    expect(spies.groupEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it("routes each level to its console method", () => {
+    const logger = createLogger("debug");
+
+    logger.log("error", "e");
+    logger.log("warn", "w");
+    logger.log("info", "i");
+    logger.log("debug", "d");
+    logger.log("off", "nothing");
+
+    expect(spies.error).toHaveBeenCalledWith("e");
+    expect(spies.warn).toHaveBeenCalledWith("w");
+    expect(spies.log).toHaveBeenCalledWith("i");
+    expect(spies.debug).toHaveBeenCalledWith("d");
+    expect(totalCalls()).toBe(4);
+  });
+});

--- a/packages/gill-extra/src/logger.ts
+++ b/packages/gill-extra/src/logger.ts
@@ -1,0 +1,173 @@
+/**
+ * How much console output the library is allowed to emit.
+ *
+ * Levels are ordered by severity: each level enables itself and everything
+ * more severe. `"off"` silences the library entirely -- nothing reaches the
+ * console.
+ *
+ * - `"off"` -- no output at all.
+ * - `"error"` -- failures only.
+ * - `"warn"` -- failures and recoverable problems.
+ * - `"info"` -- the above plus notable lifecycle information. The default.
+ * - `"debug"` -- everything, including verbose per-event dumps.
+ */
+export type LogLevel = "off" | "error" | "warn" | "info" | "debug";
+
+/**
+ * The log level used when none is configured.
+ */
+export const DEFAULT_LOG_LEVEL: LogLevel = "info";
+
+/**
+ * Severity ranking used to decide whether a message passes the configured
+ * level. `off` is 0 so that nothing is ever emitted at or below it.
+ */
+const LOG_LEVEL_SEVERITY: Record<LogLevel, number> = {
+  off: 0,
+  error: 1,
+  warn: 2,
+  info: 3,
+  debug: 4,
+};
+
+/**
+ * A level-aware console.
+ *
+ * Every message carries the level it should be emitted at; the logger drops
+ * the ones the configured level does not allow. Grouping takes a level too, so
+ * a group is only opened (and only closed) when its contents would be printed.
+ */
+export interface Logger {
+  /**
+   * The level this logger was created with.
+   */
+  readonly level: LogLevel;
+  /**
+   * Whether messages at `level` are emitted. Useful for skipping expensive
+   * work that only exists to produce a log line.
+   */
+  isEnabled: (level: LogLevel) => boolean;
+  /**
+   * Emits `args` at an explicit level.
+   */
+  log: (level: LogLevel, ...args: unknown[]) => void;
+  /**
+   * Emits `args` at the `"error"` level.
+   */
+  error: (...args: unknown[]) => void;
+  /**
+   * Emits `args` at the `"warn"` level.
+   */
+  warn: (...args: unknown[]) => void;
+  /**
+   * Emits `args` at the `"info"` level.
+   */
+  info: (...args: unknown[]) => void;
+  /**
+   * Emits `args` at the `"debug"` level.
+   */
+  debug: (...args: unknown[]) => void;
+  /**
+   * Opens a console group when `level` is enabled.
+   */
+  group: (level: LogLevel, ...args: unknown[]) => void;
+  /**
+   * Opens a collapsed console group when `level` is enabled.
+   */
+  groupCollapsed: (level: LogLevel, ...args: unknown[]) => void;
+  /**
+   * Closes a group opened at `level`. Takes the level so that a group which
+   * was never opened is never closed.
+   */
+  groupEnd: (level: LogLevel) => void;
+}
+
+/**
+ * Creates a {@link Logger} that writes to the console, dropping anything less
+ * severe than `level`.
+ *
+ * @param level - The maximum verbosity to emit. Defaults to
+ *   {@link DEFAULT_LOG_LEVEL}.
+ *
+ * @example
+ * ```ts
+ * const logger = createLogger("warn");
+ * logger.warn("this prints");
+ * logger.info("this does not");
+ * ```
+ */
+export function createLogger(level: LogLevel = DEFAULT_LOG_LEVEL): Logger {
+  const threshold = LOG_LEVEL_SEVERITY[level];
+
+  const isEnabled = (messageLevel: LogLevel): boolean => {
+    const severity = LOG_LEVEL_SEVERITY[messageLevel];
+    // `off` is not a level a message can be emitted at, only one that silences.
+    return severity > 0 && severity <= threshold;
+  };
+
+  const log = (messageLevel: LogLevel, ...args: unknown[]): void => {
+    if (!isEnabled(messageLevel)) {
+      return;
+    }
+    switch (messageLevel) {
+      case "error": {
+        console.error(...args);
+        break;
+      }
+      case "warn": {
+        console.warn(...args);
+        break;
+      }
+      case "debug": {
+        console.debug(...args);
+        break;
+      }
+      default: {
+        console.log(...args);
+        break;
+      }
+    }
+  };
+
+  return {
+    level,
+    isEnabled,
+    log,
+    error: (...args: unknown[]) => {
+      log("error", ...args);
+    },
+    warn: (...args: unknown[]) => {
+      log("warn", ...args);
+    },
+    info: (...args: unknown[]) => {
+      log("info", ...args);
+    },
+    debug: (...args: unknown[]) => {
+      log("debug", ...args);
+    },
+    group: (messageLevel: LogLevel, ...args: unknown[]) => {
+      if (isEnabled(messageLevel)) {
+        console.group(...args);
+      }
+    },
+    groupCollapsed: (messageLevel: LogLevel, ...args: unknown[]) => {
+      if (isEnabled(messageLevel)) {
+        console.groupCollapsed(...args);
+      }
+    },
+    groupEnd: (messageLevel: LogLevel) => {
+      if (isEnabled(messageLevel)) {
+        console.groupEnd();
+      }
+    },
+  };
+}
+
+/**
+ * The logger used by functions that are not given one. Emits at
+ * {@link DEFAULT_LOG_LEVEL}.
+ *
+ * Prefer passing the logger configured on `GrillProvider` /
+ * `GrillHeadlessProvider` so that a single `logLevel` controls all output.
+ */
+export const defaultLogger: Logger = createLogger(DEFAULT_LOG_LEVEL);

--- a/packages/gill-extra/src/poll-confirm-transaction.ts
+++ b/packages/gill-extra/src/poll-confirm-transaction.ts
@@ -1,7 +1,9 @@
 import type { Signature } from "@solana/kit";
 import type { SolanaClient } from "gill";
 import type { ConfirmedTransaction } from "./get-confirmed-transaction.js";
+import type { Logger } from "./logger.js";
 import { getConfirmedTransaction } from "./get-confirmed-transaction.js";
+import { defaultLogger } from "./logger.js";
 
 export interface PollConfirmTransactionOptions {
   signature: Signature;
@@ -9,6 +11,10 @@ export interface PollConfirmTransactionOptions {
   rpc: SolanaClient["rpc"];
   maxRetries?: number;
   retryInterval?: number;
+  /**
+   * Logger used for status check failures. Defaults to {@link defaultLogger}.
+   */
+  logger?: Logger | undefined;
 }
 
 /**
@@ -24,6 +30,7 @@ export async function pollConfirmTransaction({
   rpc,
   maxRetries = 30,
   retryInterval = 1000,
+  logger = defaultLogger,
 }: PollConfirmTransactionOptions): Promise<ConfirmedTransaction> {
   let confirmed = false;
   let confirmationError: Error | null = null;
@@ -61,7 +68,7 @@ export async function pollConfirmTransaction({
       });
       retries++;
     } catch (error) {
-      console.error("Error checking transaction status:", error);
+      logger.error("Error checking transaction status:", error);
       throw error;
     }
   }

--- a/packages/grill/README.md
+++ b/packages/grill/README.md
@@ -100,6 +100,7 @@ The main provider with built-in toast notifications:
   showToasts={true} // Show transaction toasts (default: true)
   successToastDuration={5000} // Success toast duration (default: 5000)
   errorToastDuration={7000} // Error toast duration (default: 7000)
+  logLevel="info" // Console verbosity (default: "info")
   onTransactionStatusEvent={(event) => {
     // Optional: Handle transaction events manually
     console.log("Transaction event:", event);
@@ -107,6 +108,33 @@ The main provider with built-in toast notifications:
 >
   {children}
 </GrillProvider>
+```
+
+#### Console logging
+
+Everything grill writes to the console goes through the `logLevel` prop, which
+both providers accept:
+
+| Level     | What it emits                                                |
+| --------- | ------------------------------------------------------------ |
+| `"off"`   | Nothing at all                                               |
+| `"error"` | Failed transactions and simulations, dropped subscriptions   |
+| `"warn"`  | The above, plus recoverable problems                         |
+| `"info"`  | The above, plus notable lifecycle information (**default**)  |
+| `"debug"` | Everything, including per-event transaction status dumps     |
+
+```tsx
+<GrillProvider logLevel={import.meta.env.DEV ? "debug" : "error"}>
+  {children}
+</GrillProvider>
+```
+
+Use `useLogger()` to route your own logging through the same setting, so an app
+built on grill goes quiet with a single prop:
+
+```tsx
+const logger = useLogger();
+logger.debug("swap quote", quote);
 ```
 
 ### GrillHeadlessProvider

--- a/packages/grill/src/contexts/grill-context.ts
+++ b/packages/grill/src/contexts/grill-context.ts
@@ -1,6 +1,7 @@
 import type { DataLoader } from "@macalinao/dataloader-es";
 import type {
   GetExplorerLinkFunction,
+  Logger,
   SendTXFunction,
   TokenMetadataValidator,
 } from "@macalinao/gill-extra";
@@ -48,6 +49,12 @@ export interface GrillContextValue {
    * Validates the JSON fetched from a token's metadata URI.
    */
   validateTokenMetadata: TokenMetadataValidator;
+
+  /**
+   * Level-aware console logger built from the provider's `logLevel` prop.
+   * Everything the library prints goes through it.
+   */
+  logger: Logger;
 }
 
 /**

--- a/packages/grill/src/contexts/subscription-context.test.ts
+++ b/packages/grill/src/contexts/subscription-context.test.ts
@@ -2,6 +2,7 @@ import type { Address, Lamports } from "@solana/kit";
 import type { RpcSubscriptions, SolanaRpcSubscriptionsApi } from "gill";
 import type { AccountDecoder } from "./subscription-context.js";
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { createLogger } from "@macalinao/gill-extra";
 import { address, getBase64Decoder, lamports } from "@solana/kit";
 import { QueryClient } from "@tanstack/react-query";
 import { createAccountQueryKey } from "../query-keys.js";
@@ -401,5 +402,33 @@ describe("createSubscriptionManager", () => {
     second();
     expect(manager.getSubscriptionCount(ACCOUNT)).toBe(0);
     expect(rpc.channels[0]?.abortSignal.aborted).toBe(true);
+  });
+
+  it("writes nothing to the console when the logger is off", async () => {
+    const consoleError = spyOn(console, "error").mockImplementation(() => {
+      // Nothing should reach this; the assertion below proves it.
+    });
+
+    try {
+      const rpc = createFakeRpcSubscriptions();
+      const manager = createSubscriptionManager(
+        rpc.rpcSubscriptions,
+        queryClient,
+        { ...FAST_RECONNECT, logger: createLogger("off") },
+      );
+
+      const unsubscribe = manager.subscribe(ACCOUNT, decoder);
+      await waitFor(() => rpc.channels.length === 1, "the first subscription");
+
+      // A dropped connection is the manager's loudest log line.
+      rpc.channels[0]?.fail(new Error("socket closed unexpectedly"));
+      await waitFor(() => rpc.channels.length === 2, "a reconnect");
+
+      expect(consoleError).not.toHaveBeenCalled();
+
+      unsubscribe();
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 });

--- a/packages/grill/src/contexts/subscription-context.ts
+++ b/packages/grill/src/contexts/subscription-context.ts
@@ -1,3 +1,4 @@
+import type { Logger } from "@macalinao/gill-extra";
 import type {
   Account,
   Address,
@@ -7,6 +8,7 @@ import type {
 } from "@solana/kit";
 import type { QueryClient } from "@tanstack/react-query";
 import type { RpcSubscriptions, SolanaRpcSubscriptionsApi } from "gill";
+import { defaultLogger } from "@macalinao/gill-extra";
 import { getBase64Encoder } from "@solana/kit";
 import { createContext, useContext } from "react";
 import { createAccountQueryKey } from "../query-keys.js";
@@ -99,6 +101,13 @@ export interface SubscriptionManagerOptions {
    * how aggressively.
    */
   reconnect?: SubscriptionReconnectConfig;
+  /**
+   * Logger used for decode and connection failures. Defaults to
+   * {@link defaultLogger}.
+   *
+   * `GrillProvider` passes a logger built from its `logLevel` prop.
+   */
+  logger?: Logger | undefined;
 }
 
 const DEFAULT_BASE_DELAY_MS = 500;
@@ -257,6 +266,7 @@ export function createSubscriptionManager(
     maxDelayMs = DEFAULT_MAX_DELAY_MS,
     stableConnectionMs = DEFAULT_STABLE_CONNECTION_MS,
   } = options.reconnect ?? {};
+  const logger = options.logger ?? defaultLogger;
 
   const subscriptions = new Map<string, SubscriptionEntry>();
 
@@ -277,7 +287,7 @@ export function createSubscriptionManager(
       const decoded = decoder(encodedAccount);
       queryClient.setQueryData(createAccountQueryKey(address), decoded);
     } catch (decodeError) {
-      console.error(
+      logger.error(
         `[SubscriptionManager] Error decoding account ${address}:`,
         decodeError,
       );
@@ -340,7 +350,7 @@ export function createSubscriptionManager(
         if (isAborted()) {
           return;
         }
-        console.error(
+        logger.error(
           `[SubscriptionManager] Subscription error for ${address}, reconnecting:`,
           error,
         );
@@ -426,7 +436,7 @@ export function createSubscriptionManager(
     // bug in the manager itself can reject here.
     void runSubscription(address, entry, abortController.signal).catch(
       (error: unknown) => {
-        console.error(
+        logger.error(
           `[SubscriptionManager] Subscription loop for ${address} stopped:`,
           error,
         );

--- a/packages/grill/src/hooks/index.ts
+++ b/packages/grill/src/hooks/index.ts
@@ -10,6 +10,7 @@ export * from "./use-associated-token-account.js";
 export * from "./use-ata-balance.js";
 export { useConnectedWallet } from "./use-connected-wallet.js";
 export { useKitWallet } from "./use-kit-wallet.js";
+export * from "./use-logger.js";
 export * from "./use-send-tx.js";
 export * from "./use-token-balance.js";
 export * from "./use-token-info.js";

--- a/packages/grill/src/hooks/use-logger.ts
+++ b/packages/grill/src/hooks/use-logger.ts
@@ -1,0 +1,19 @@
+import type { Logger } from "@macalinao/gill-extra";
+import { useGrillContext } from "../contexts/grill-context.js";
+
+/**
+ * Hook for accessing the logger configured on `GrillProvider` /
+ * `GrillHeadlessProvider` via their `logLevel` prop.
+ *
+ * Use it for app-level logging that should be silenced along with the
+ * library's own output.
+ *
+ * @example
+ * ```tsx
+ * const logger = useLogger();
+ * logger.debug("swap quote", quote);
+ * ```
+ */
+export function useLogger(): Logger {
+  return useGrillContext().logger;
+}

--- a/packages/grill/src/hooks/use-token-info.ts
+++ b/packages/grill/src/hooks/use-token-info.ts
@@ -27,6 +27,7 @@ export function useTokenInfo({
     staticTokenInfo,
     fetchFromCertifiedTokenList,
     validateTokenMetadata,
+    logger,
   } = useGrillContext();
   const { data: metadataAccount } = useTokenMetadataAccount({ mint });
   const { data: mintAccount } = useMintAccount({ address: mint });
@@ -56,6 +57,7 @@ export function useTokenInfo({
         metadata: metadataAccount?.data ?? null,
         fetchFromCertifiedTokenList,
         validateMetadata: validateTokenMetadata,
+        logger,
       });
     },
     enabled:

--- a/packages/grill/src/hooks/use-token-infos.ts
+++ b/packages/grill/src/hooks/use-token-infos.ts
@@ -34,7 +34,7 @@ export type UseTokenInfosResult =
 export function useTokenInfos({
   mints,
 }: UseTokenInfosInput): UseTokenInfosResult {
-  const { staticTokenInfo, validateTokenMetadata } = useGrillContext();
+  const { staticTokenInfo, validateTokenMetadata, logger } = useGrillContext();
 
   // Filter out null/undefined mints for account fetching
   const validMints = mints?.filter((mint): mint is Address => !!mint) ?? [];
@@ -92,6 +92,7 @@ export function useTokenInfos({
             mint: mintAccount,
             metadata: metadataAccount?.data ?? null,
             validateMetadata: validateTokenMetadata,
+            logger,
           });
         },
         enabled:

--- a/packages/grill/src/providers/grill-headless-provider.tsx
+++ b/packages/grill/src/providers/grill-headless-provider.tsx
@@ -1,14 +1,22 @@
 import type {
   GetExplorerLinkFunction,
+  LogLevel,
   SolanaCluster,
   TokenMetadataValidator,
 } from "@macalinao/gill-extra";
 import type { TokenInfo } from "@macalinao/token-utils";
 import type { Address } from "gill";
 import type { FC, ReactNode } from "react";
-import type { TransactionStatusEventCallback } from "../types.js";
+import type {
+  TransactionStatusEvent,
+  TransactionStatusEventCallback,
+} from "../types.js";
 import { useSolanaClient } from "@gillsdk/react";
-import { defaultTokenMetadataValidator } from "@macalinao/gill-extra";
+import {
+  createLogger,
+  DEFAULT_LOG_LEVEL,
+  defaultTokenMetadataValidator,
+} from "@macalinao/gill-extra";
 import { createBatchAccountsLoader } from "@macalinao/solana-batch-accounts-loader";
 import { useQueryClient } from "@tanstack/react-query";
 import { getExplorerLink as defaultGetExplorerLink } from "gill";
@@ -58,6 +66,15 @@ export interface GrillHeadlessProviderProps {
    * Use "localnet" when developing locally.
    */
   cluster?: SolanaCluster;
+  /**
+   * How much the library is allowed to write to the console.
+   *
+   * Each level enables itself and everything more severe, so `"warn"` emits
+   * warnings and errors. `"off"` silences the library completely.
+   *
+   * @default "info"
+   */
+  logLevel?: LogLevel;
 }
 
 /**
@@ -78,19 +95,31 @@ export const GrillHeadlessProvider: FC<GrillHeadlessProviderProps> = ({
   children,
   maxBatchSize = 99,
   batchDurationMs = 10,
-  onTransactionStatusEvent = (e) => {
-    console.log(e);
-  },
+  onTransactionStatusEvent,
   getExplorerLink = defaultGetExplorerLink,
   staticTokenInfo = [],
   fetchFromCertifiedTokenList = true,
   validateTokenMetadata = defaultTokenMetadataValidator,
   rpcUrl,
   cluster = "mainnet-beta",
+  logLevel = DEFAULT_LOG_LEVEL,
 }) => {
   const { rpc } = useSolanaClient();
   const queryClient = useQueryClient();
   const { signer } = useKitWallet();
+
+  const logger = useMemo(() => createLogger(logLevel), [logLevel]);
+
+  // Without a handler, transaction events are dumped to the console at the
+  // debug level -- they are a firehose, so they stay quiet by default.
+  const handleTransactionStatusEvent: TransactionStatusEventCallback = useMemo(
+    () =>
+      onTransactionStatusEvent ??
+      ((event: TransactionStatusEvent) => {
+        logger.debug(event);
+      }),
+    [onTransactionStatusEvent, logger],
+  );
 
   const accountLoader = useMemo(
     () =>
@@ -119,19 +148,21 @@ export const GrillHeadlessProvider: FC<GrillHeadlessProviderProps> = ({
         signer,
         rpc,
         refetchAccounts,
-        onTransactionStatusEvent,
+        onTransactionStatusEvent: handleTransactionStatusEvent,
         getExplorerLink,
         rpcUrl,
         cluster,
+        logger,
       }),
     [
       signer,
       rpc,
       refetchAccounts,
-      onTransactionStatusEvent,
+      handleTransactionStatusEvent,
       getExplorerLink,
       rpcUrl,
       cluster,
+      logger,
     ],
   );
 
@@ -141,7 +172,7 @@ export const GrillHeadlessProvider: FC<GrillHeadlessProviderProps> = ({
   );
 
   return (
-    <SubscriptionProvider>
+    <SubscriptionProvider logger={logger}>
       <GrillContext.Provider
         value={{
           accountLoader,
@@ -151,6 +182,7 @@ export const GrillHeadlessProvider: FC<GrillHeadlessProviderProps> = ({
           staticTokenInfo: staticTokenInfoMap,
           fetchFromCertifiedTokenList,
           validateTokenMetadata,
+          logger,
         }}
       >
         {children}

--- a/packages/grill/src/providers/grill-provider.tsx
+++ b/packages/grill/src/providers/grill-provider.tsx
@@ -1,7 +1,8 @@
 import type { FC } from "react";
 import type { TransactionStatusEvent } from "../types.js";
 import type { GrillHeadlessProviderProps } from "./grill-headless-provider.js";
-import { useCallback, useRef } from "react";
+import { createLogger, DEFAULT_LOG_LEVEL } from "@macalinao/gill-extra";
+import { useCallback, useMemo, useRef } from "react";
 import { toast } from "sonner";
 import { GrillHeadlessProvider } from "./grill-headless-provider.js";
 
@@ -44,10 +45,15 @@ export const GrillProvider: FC<GrillProviderProps> = ({
   showToasts = true,
   successToastDuration = 5000,
   errorToastDuration = 7000,
+  logLevel = DEFAULT_LOG_LEVEL,
   ...props
 }) => {
   // Store toast IDs for each transaction
   const toastIds = useRef<Map<string, string | number>>(new Map());
+
+  // A separate logger from the headless provider's: this component sits above
+  // GrillContext, so it cannot read the one on the context.
+  const logger = useMemo(() => createLogger(logLevel), [logLevel]);
 
   const handleTransactionStatus = useCallback(
     (event: TransactionStatusEvent) => {
@@ -83,7 +89,7 @@ export const GrillProvider: FC<GrillProviderProps> = ({
         }
 
         case "error-transaction-send-failed": {
-          console.error("Error sending transaction", event);
+          logger.error("Error sending transaction", event);
           const description = event.errorMessage;
 
           if (existingToastId !== undefined) {
@@ -161,7 +167,7 @@ export const GrillProvider: FC<GrillProviderProps> = ({
           const description = `Transaction: ${event.sig.slice(0, 8)}...${event.sig.slice(-8)}`;
           const action = createExplorerAction(event.explorerLink);
 
-          console.log({ event, existingToastId, description, action });
+          logger.debug({ event, existingToastId, description, action });
 
           if (existingToastId !== undefined) {
             // Update existing toast to success
@@ -185,7 +191,7 @@ export const GrillProvider: FC<GrillProviderProps> = ({
         }
 
         case "error-transaction-failed": {
-          console.error("Transaction failed", event);
+          logger.error("Transaction failed", event);
           const description = event.errorMessage;
           const action = createExplorerAction(event.explorerLink);
 
@@ -210,7 +216,7 @@ export const GrillProvider: FC<GrillProviderProps> = ({
           break;
         }
         case "error-simulation-failed": {
-          console.error("Simulation failed", event);
+          logger.error("Simulation failed", event);
           const description = `Simulation failed: ${event.errorMessage}`;
           if (existingToastId !== undefined) {
             // Update existing toast to error
@@ -237,12 +243,14 @@ export const GrillProvider: FC<GrillProviderProps> = ({
       showToasts,
       successToastDuration,
       errorToastDuration,
+      logger,
     ],
   );
 
   return (
     <GrillHeadlessProvider
       onTransactionStatusEvent={handleTransactionStatus}
+      logLevel={logLevel}
       {...props}
     >
       {children}

--- a/packages/grill/src/providers/subscription-provider.tsx
+++ b/packages/grill/src/providers/subscription-provider.tsx
@@ -1,5 +1,7 @@
+import type { Logger } from "@macalinao/gill-extra";
 import type { FC, ReactNode } from "react";
 import { useSolanaClient } from "@gillsdk/react";
+import { defaultLogger } from "@macalinao/gill-extra";
 import { useQueryClient } from "@tanstack/react-query";
 import { useMemo } from "react";
 import {
@@ -9,6 +11,12 @@ import {
 
 export interface SubscriptionProviderProps {
   children: ReactNode;
+  /**
+   * Logger used for subscription errors. Defaults to {@link defaultLogger}.
+   *
+   * `GrillHeadlessProvider` passes a logger built from its `logLevel` prop.
+   */
+  logger?: Logger;
 }
 
 /**
@@ -34,14 +42,15 @@ export interface SubscriptionProviderProps {
  */
 export const SubscriptionProvider: FC<SubscriptionProviderProps> = ({
   children,
+  logger = defaultLogger,
 }) => {
   const { rpcSubscriptions } = useSolanaClient();
   const queryClient = useQueryClient();
 
   // Create subscription manager for real-time account updates
   const subscriptionManager = useMemo(
-    () => createSubscriptionManager(rpcSubscriptions, queryClient),
-    [rpcSubscriptions, queryClient],
+    () => createSubscriptionManager(rpcSubscriptions, queryClient, { logger }),
+    [rpcSubscriptions, queryClient, logger],
   );
 
   return (

--- a/packages/grill/src/utils/internal/create-send-tx.ts
+++ b/packages/grill/src/utils/internal/create-send-tx.ts
@@ -3,6 +3,7 @@
 // tsc types them correctly. Re-enable once typescript-go handles these signatures.
 import type {
   GetExplorerLinkFunction,
+  Logger,
   SendTXFunction,
   SendTXOptions,
   SolanaCluster,
@@ -17,6 +18,7 @@ import type {
 import type { SolanaClient } from "gill";
 import type { TransactionStatusEvent } from "../../types.js";
 import {
+  defaultLogger,
   getSignatureFromBytes,
   logTransactionSimulation,
   parseTransactionError,
@@ -45,6 +47,10 @@ export interface CreateSendTXParams {
    * Defaults to "mainnet-beta".
    */
   cluster?: SolanaCluster | undefined;
+  /**
+   * Logger for transaction diagnostics. Defaults to {@link defaultLogger}.
+   */
+  logger?: Logger | undefined;
 }
 
 /**
@@ -59,6 +65,7 @@ export const createSendTX = ({
   getExplorerLink,
   rpcUrl,
   cluster = "mainnet-beta",
+  logger = defaultLogger,
 }: CreateSendTXParams): SendTXFunction => {
   const simulateTransaction = simulateTransactionFactory({ rpc });
   return async (
@@ -125,6 +132,7 @@ export const createSendTX = ({
           transactionMessage: finalTransactionMessage,
           cluster,
           rpcUrl,
+          logger,
         });
 
         const logs = simulationResult.value.logs ?? [];
@@ -180,6 +188,7 @@ export const createSendTX = ({
         signature: sig,
         lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
         rpc,
+        logger,
       });
 
       onTransactionStatusEvent({
@@ -199,20 +208,20 @@ export const createSendTX = ({
         } else {
           // Refetch in background without waiting
           refetchAccounts(writableAccounts).catch((error: unknown) => {
-            console.warn("Failed to refetch accounts in background:", error);
+            logger.warn("Failed to refetch accounts in background:", error);
           });
         }
       }
 
       if (result.meta?.logMessages) {
-        console.log(name, result.meta.logMessages.join("\n"));
+        logger.debug(name, result.meta.logMessages.join("\n"));
       }
 
       // Return the signature as a base58 string
       return sig;
     } catch (error: unknown) {
       // Log error details for debugging
-      console.error(`${name} transaction failed:`, error);
+      logger.error(`${name} transaction failed:`, error);
 
       // Extract error logs
       const isLogs = (value: unknown): value is string[] =>
@@ -241,9 +250,9 @@ export const createSendTX = ({
 
       const errorLogs = extractErrorLogs(error);
       if (errorLogs.length > 0) {
-        console.log("Transaction logs:");
+        logger.error("Transaction logs:");
         for (const log of errorLogs) {
-          console.log("  ", log);
+          logger.error("  ", log);
         }
       }
 

--- a/packages/wallet-adapter-compat/src/wallet-transaction-sending-signer.ts
+++ b/packages/wallet-adapter-compat/src/wallet-transaction-sending-signer.ts
@@ -9,11 +9,7 @@ import type {
   TransactionOrVersionedTransaction,
 } from "@solana/wallet-adapter-base";
 import type { Connection, TransactionSignature } from "@solana/web3.js";
-import {
-  address,
-  getBase58Encoder,
-  getBase64EncodedWireTransaction,
-} from "@solana/kit";
+import { address, getBase58Encoder } from "@solana/kit";
 import {
   PublicKey,
   VersionedMessage,
@@ -66,7 +62,6 @@ export function createWalletTransactionSendingSigner(
       // Process each transaction
       for (const transaction of transactions) {
         try {
-          console.log("TX", getBase64EncodedWireTransaction(transaction));
           const msg = VersionedMessage.deserialize(
             Uint8Array.from(transaction.messageBytes),
           );
@@ -78,7 +73,6 @@ export function createWalletTransactionSendingSigner(
               vt.addSignature(new PublicKey(publicKey), signature);
             }
           }
-          // console.log("v1", Buffer.from(vt.serialize()).toString("base64"));
           const sig = await walletAdapter.sendTransaction(vt, connection);
           const sigBytes = getBase58Encoder().encode(sig) as SignatureBytes;
 


### PR DESCRIPTION
## Why

The library wrote to the console unconditionally — failed simulations, transaction logs, subscription errors, a full dump of every transaction status event, and the base64 wire bytes of every transaction sent through the wallet adapter. All of that reached end users of apps built on grill with no way to turn it down.

## What changed

**A level-aware logger in `@macalinao/gill-extra`** (`src/logger.ts`): `LogLevel` (`"off" | "error" | "warn" | "info" | "debug"`), a `Logger` interface, `createLogger(level)`, `defaultLogger`, and `DEFAULT_LOG_LEVEL` (`"info"`). Each level enables itself and everything more severe; `"off"` emits nothing at all. Grouping takes a level too (`group(level, ...)` / `groupEnd(level)`), so a group is only opened — and only closed — when its contents would print. `isEnabled(level)` lets callers skip work that exists only to produce a log line.

**`logLevel` prop** on `GrillProvider` and `GrillHeadlessProvider`, defaulting to `"info"`. The headless provider builds the logger and puts it on `GrillContext`; `GrillProvider` builds its own from the same prop (it sits above the context) and forwards `logLevel` down.

**How gill-extra receives the level:** its logging helpers take an optional `logger` on their existing params object and fall back to `defaultLogger`, so the public API is unchanged for existing callers. Grill passes its configured logger into `logTransactionSimulation`, `pollConfirmTransaction` (via `createSendTX`), `fetchTokenInfo` (via `useTokenInfo` / `useTokenInfos`), and `createSubscriptionManager` (via `SubscriptionProvider`).

**Level assignments:** failed transactions/simulations and subscription errors at `error`; background refetch failures and the certified-token-list fallback at `warn`; a successful simulation report at `info`; verbose transaction logs and the per-event status dump at `debug`.

**`useLogger()`** returns the configured logger so app code can be silenced by the same prop. Demonstrated in the example app (`wrapped-sol.tsx`), which also passes `logLevel` on its provider.

**`@macalinao/wallet-adapter-compat`** no longer logs `console.log("TX", getBase64EncodedWireTransaction(...))` on every send. That was a leftover debug statement, so it is deleted rather than routed through a logger — matching the rewrite of the same file in #164 to keep that merge trivial. The two `console.error` calls in that package stay: they only fire on genuine failures, and `WalletAdapterCompatProvider` sits outside `GrillProvider`, so it cannot read the configured logger.

## Behavior change

Apps that never set `onTransactionStatusEvent` on the headless provider used to get a `console.log` per status event. That now sits at `debug`, so it is quiet at the `"info"` default. Everything else prints as before unless `logLevel` is lowered.

## Verification

- `bun run build` — clean
- `bun run lint:fix` then `bun run lint` — clean (ast-grep + oxlint type-aware + oxfmt + tsc)
- `bun run test` — 19/19 tasks pass, including new coverage: `packages/gill-extra/src/logger.test.ts` (level filtering, `"off"` produces zero console calls, default is `"info"`, per-level console method routing, group gating), level tests in `log-transaction-simulation.test.ts`, and a subscription-manager test asserting an `"off"` logger stays silent while still reconnecting.
- `grep -rn "console\." packages/*/src` — what remains is JSDoc examples, the two wallet-adapter-compat failure paths above, and two error paths in `@macalinao/quarry` (see follow-up).

Changeset: `.changeset/configurable-log-level.md` — minor for `@macalinao/grill` and `@macalinao/gill-extra`, patch for `@macalinao/wallet-adapter-compat`.

## Follow-up

`@macalinao/quarry` still calls `console.error` in `claim-and-redeem-all-rewards-mm.ts` (lines 65, 89). It is a non-React utility package with no provider to hang a logger off, and those are genuine error paths, so they are left as-is here.

## Summary by Sourcery

Introduce configurable, level-based logging across grill and gill-extra so applications can control or silence library console output.

New Features:
- Add a level-aware logger in @macalinao/gill-extra with LogLevel, Logger, createLogger, defaultLogger, and DEFAULT_LOG_LEVEL, and expose it from the package.
- Add a logLevel prop to GrillProvider and GrillHeadlessProvider to control library logging, and a useLogger hook so app code can use the same logger.
- Allow gill-extra helpers (transaction simulation, token info fetching, transaction status polling, subscriptions) to accept an optional logger while defaulting to the shared logger.

Bug Fixes:
- Remove the leftover transaction wire-bytes debug log from @macalinao/wallet-adapter-compat so sends no longer spam the console.

Enhancements:
- Route existing grill and gill-extra console output through the new logger with appropriate severity levels, including transaction flows, simulations, token metadata fetches, and subscription errors.
- Ensure transaction status events are logged at a debug level only when no handler is provided, reducing noisy default output.
- Make subscription manager and background refetch logic respect the configured log level, including silent operation when logging is turned off.

Build:
- Add a changeset marking minor releases for @macalinao/grill and @macalinao/gill-extra and a patch for @macalinao/wallet-adapter-compat to reflect the new logging configuration.

Documentation:
- Update GrillProvider setup docs and README to explain logLevel, console logging behavior, and the useLogger hook, with examples for development vs production verbosity and non-React usage.

Tests:
- Add comprehensive tests for the logger utility (level filtering, default level, console method routing, grouping behavior) and extend existing tests for transaction simulation and subscriptions to cover logger integration and off-level silence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable logging levels: `off`, `error`, `warn`, `info`, and `debug`.
  * Added `useLogger()` for application-level logging controlled by provider settings.
  * Extended transaction, subscription, and token-information workflows with configurable logging.

* **Bug Fixes**
  * Suppressed unwanted console output when logging is disabled.
  * Improved consistent routing of errors, warnings, confirmations, and simulation results.

* **Documentation**
  * Documented logging configuration, level filtering, and custom logger usage in setup guides and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->