### PR TITLE
chore: align release automation with changesets v3

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
+  "$schema": "https://unpkg.com/@changesets/config@4.0.0/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": true,
   "fixed": [],
@@ -8,5 +8,9 @@
   "baseBranch": "master",
   "updateInternalDependencies": "patch",
   "updateInternalDependents": "always",
-  "ignore": []
+  "ignore": [],
+  "privatePackages": {
+    "version": true,
+    "tag": false
+  }
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,11 +69,14 @@ jobs:
         id: changesets
         uses: changesets/action@v2
         with:
-          # This expects you to have a script called release which does a build for your packages and calls changeset publish
-          publish: bun run ci:publish
-          version: bun run ci:version
-          commit: "chore: release packages"
-          title: "chore: release packages"
+          # Input names below are the changesets/action v2 spelling; v1 called
+          # these publish/version/commit/title. v2 ignores the old names
+          # silently, so a rename that misses one degrades to "open a release
+          # PR" instead of publishing.
+          publish-script: bun run ci:publish
+          version-script: bun run ci:version
+          commit-message: "chore: release packages"
+          pr-title: "chore: release packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/scripts/ci-publish.sh
+++ b/scripts/ci-publish.sh
@@ -84,6 +84,7 @@ fi
 # Only tag once every package is actually on the registry, so tags never claim a
 # release that did not happen. A failed run is retried in full by the next one.
 echo "Creating git tags..."
-changeset tag
+# `changeset tag` in CLI v2; renamed to `git-tag` in v3.
+changeset git-tag
 
 echo "Publishing complete!"


### PR DESCRIPTION
The dependabot bump of `changesets/action` v1 → v2 (#213) broke releases. The action v2 refuses to run against Changesets CLI v2:

```
##[error]This version of the Changesets action is designed to work with
Changesets CLI v3. Changesets CLI v2 is not supported; use Changesets
action v1 instead, which is compatible with CLI v2.
```

It has failed on every push to master since — on the #224 merge and again on the merge of the version PR #207. **Nothing has published to npm since that dependabot PR landed:**

| package | in repo | on npm |
| --- | --- | --- |
| `@macalinao/grill` | 0.17.0 | 0.16.0 |
| `@macalinao/gill-extra` | 0.10.0 | 0.9.0 |

Rather than pinning the action back to v1, this moves everything else forward to match.

## Changes

Rebased onto master. The `@changesets/cli` `^2.31.1` → `^3.0.1` bump and its lockfile churn — originally part of this PR — landed independently in #223, so they're gone from the diff. What remains is the workflow, script, and config that v3 renamed out from under us:

- **`.github/workflows/release.yml`** — action v2 renamed every input this workflow passes: `publish`/`version`/`commit`/`title` → `publish-script`/`version-script`/`commit-message`/`pr-title`. v2 ignores the old names with only a warning, which is why the run still got as far as the CLI version check.
- **`scripts/ci-publish.sh`** — `changeset tag` was renamed to `changeset git-tag` in v3. Without this the publish would have succeeded and then died at the tagging step, leaving packages on npm with no git tags.
- **`.changeset/config.json`** — `$schema` → `@changesets/config@4.0.0`, and `privatePackages` pinned to the v2 default `{version: true, tag: false}`. v3 stops versioning private packages by default, which would silently freeze `example-dapp` at its current version.

## Verification

Against the installed binary rather than the release notes, on the rebased branch: `changeset --version` reports `3.0.1`, `changeset --help` lists `git-tag` and no longer lists `tag`, and `changeset status` parses the updated config without complaint (and reports the 10 packages currently pending a patch bump).

Full suite inside the nix devshell: `bun run lint` 21/21, `bun run test` 19/19.

## Notes

- No changeset: only CI config and scripts changed — no published package's source or dependencies.
- Merging this triggers a Release run that should publish the versions currently stranded off the registry. Worth watching that run.
- Open question for a follow-up: `privatePackages.version: true` preserves today's behavior, but if you'd rather stop version-bumping `example-dapp` entirely, dropping that key adopts the v3 default instead.

https://claude.ai/code/session_013evZipdNibVb6pjsSE5Mcp

## Summary by Sourcery

Align release automation with Changesets v3 to resume reliable package publishing and tagging.

Bug Fixes:
- Restore release publishing compatibility with Changesets action and CLI v3 so packages can be published and tagged successfully.

Enhancements:
- Update Changesets configuration to preserve versioning behavior for private packages under CLI v3.

CI:
- Align the release workflow inputs with the Changesets action v2 interface.

Chores:
- Update the publish script to use the Changesets v3 git-tag command.