### PR TITLE
chore: widen @tanstack/react-query peer range to ^5.66.9

### DIFF
--- a/.changeset/widen-react-query-peer-range.md
+++ b/.changeset/widen-react-query-peer-range.md
@@ -1,0 +1,12 @@
+---
+"@macalinao/grill": patch
+---
+
+Widen the `@tanstack/react-query` peer range from `^5.102.8` to `^5.66.9`.
+
+Nothing in this package needs a 5.102.x release — it only uses `useQuery`,
+`useQueries` (with `combine`), `useQueryClient`, and the `QueryClient` cache
+methods. `5.66.9` is the lowest v5 release the package type-checks against: it
+shipped the improved `useQueries` inference for dynamically built query arrays
+(TanStack Query PR #8624), which `useAccounts` and `useTokenInfos` rely on.
+Apps pinned anywhere in 5.66.9 – 5.102.7 no longer get a spurious peer conflict.

--- a/bun.lock
+++ b/bun.lock
@@ -165,7 +165,7 @@
       },
       "peerDependencies": {
         "@solana/kit": "catalog:peer",
-        "@tanstack/react-query": "^5.102.8",
+        "@tanstack/react-query": "catalog:peer",
         "gill": "catalog:",
         "react": "catalog:peer",
         "sonner": "^2",
@@ -335,6 +335,7 @@
   "catalogs": {
     "peer": {
       "@solana/kit": "^6 || ^7 || ^8",
+      "@tanstack/react-query": "^5.66.9",
       "react": "^18 || ^19",
       "react-dom": "^18 || ^19",
       "zod": "^4",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "catalogs": {
       "peer": {
         "@solana/kit": "^6 || ^7 || ^8",
+        "@tanstack/react-query": "^5.66.9",
         "react": "^18 || ^19",
         "react-dom": "^18 || ^19",
         "zod": "^4"

--- a/packages/grill/package.json
+++ b/packages/grill/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "@solana/kit": "catalog:peer",
-    "@tanstack/react-query": "^5.102.8",
+    "@tanstack/react-query": "catalog:peer",
     "gill": "catalog:",
     "react": "catalog:peer",
     "sonner": "^2"


### PR DESCRIPTION
## What

`@macalinao/grill` declared its TanStack Query peer as a literal `"^5.102.8"`, while every other peer in that same block resolves through the workspace peer catalog (`catalog:peer`). That pin marked consumers on 5.66.9–5.102.7 as incompatible for no reason.

- Added `@tanstack/react-query: "^5.66.9"` to `workspaces.catalogs.peer` in the root `package.json`.
- Changed `packages/grill`'s peerDependency to `"catalog:peer"`.
- Dev-time resolution is untouched — the non-peer `catalog:` entry stays at `^5.102.8`, and `bun.lock` still resolves 5.102.8 everywhere.

`packages/grill` is the only workspace package that declares a react-query peer. `packages/react-quarry` has none (it gets it transitively via its `@macalinao/grill` peer), so there was nothing to align there.

## Why `^5.66.9` and not `^5`

The package's entire TanStack Query surface is `useQuery`, `useQueries` (with `combine`), `useQueryClient`, `QueryClient` (`setQueryData` / `getQueryData` / `getQueryState` / `invalidateQueries` / `refetchQueries` / `clear`), the `UseQueryResult` / `UseQueryOptions` types, and the `networkMode` / `staleTime` / `gcTime` / `enabled` options. All of that has existed since 5.0.0 — I verified it against the published 5.0.0 `.d.ts` files rather than from memory.

But `^5` does not actually type-check. I bisected by installing each candidate version into `packages/grill/node_modules` and running `tsc --noEmit`:

| version | result |
| --- | --- |
| 5.0.0 | fail |
| 5.61.4 | fail |
| 5.66.8 | fail |
| **5.66.9** | **pass** |
| 5.67.0 → 5.102.8 | pass |

Below 5.66.9, `useQueries` cannot infer element types for a `.map()`-built query array, so `combine` receives `UseQueryResult<unknown>` and the typed result fails to assign:

```
src/hooks/use-accounts.ts(95,3): error TS2322: Type '{ isLoading: true; data: unknown[]; ... }'
  is not assignable to type 'UseAccountsResult<TDecodedData>'.
```

5.66.9 is a single-fix release: [PR #8624](https://github.com/TanStack/query/pull/8624), _"types: prevent type errors and improve inference for dynamic queries on useQueries and useSuspenseQueries"_ (2025-02-21). Diffing `useQueries.d.ts` between 5.66.8 and 5.66.9 shows exactly that change — `QueriesResults` gained a per-element mapped branch in place of the `Array<UseQueryResult>` fallback. `useAccounts`, `useTokenInfos` and `createPdasHook` all depend on it.

So this widens the range by ~36 minors while staying honest about what the code needs. If you'd rather claim plain `^5`, `use-accounts.ts` / `use-token-infos.ts` / `create-pdas-hook.ts` would need explicit generics on their `useQueries` calls.

Worth noting separately: `@gillsdk/react`, a direct dependency of `@macalinao/grill`, declares its own `@tanstack/react-query: "^5.61.4"` peer — lower than our floor, so ours governs.

## Verification

- `bun install --ignore-scripts` — lockfile diff is only the two range lines; resolved versions unchanged at 5.102.8.
- `bun run build` — 12/12 tasks pass.
- `bun run lint:fix` — clean, no files modified (ast-grep + oxlint type-aware + oxfmt + typecheck across 21 tasks).
- `bun run test` — 19/19 tasks pass.

Changeset: `.changeset/widen-react-query-peer-range.md` (`@macalinao/grill`, patch).

https://claude.ai/code/session_01TADcofZRc9DSZWbsLpn2Jb

## Summary by Sourcery

Widen @macalinao/grill’s TanStack Query peer compatibility to the earliest v5 release that supports its required query type inference.

Bug Fixes:
- Widen the @macalinao/grill @tanstack/react-query peer range to support compatible 5.66.9–5.102.x consumers without spurious peer conflicts.

Enhancements:
- Centralize the TanStack Query peer version in the workspace peer catalog while preserving the existing development resolution.

Chores:
- Add a patch changeset documenting the updated peer compatibility floor.